### PR TITLE
fixes to match cleanup in sail-riscv:master-cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,15 +18,17 @@ SAIL_DEFAULT_INST = $(SAIL_RISCV_MODEL_DIR)/riscv_insts_base.sail \
 SAIL_SEQ_INST  = $(SAIL_DEFAULT_INST) $(SAIL_RISCV_MODEL_DIR)/riscv_jalr_seq.sail
 SAIL_RMEM_INST = $(SAIL_DEFAULT_INST) $(SAIL_RISCV_MODEL_DIR)/riscv_jalr_rmem.sail $(SAIL_RISCV_MODEL_DIR)/riscv_insts_rmem.sail
 
-SAIL_SEQ_INST_SRCS  = $(SAIL_CHECK_SRCS) $(SAIL_RISCV_MODEL_DIR)/riscv_insts_begin.sail $(SAIL_SEQ_INST)  $(SAIL_RISCV_MODEL_DIR)/riscv_insts_end.sail
-SAIL_RMEM_INST_SRCS = $(SAIL_CHECK_SRCS) $(SAIL_RISCV_MODEL_DIR)/riscv_insts_begin.sail $(SAIL_RMEM_INST) $(SAIL_RISCV_MODEL_DIR)/riscv_insts_end.sail
+SAIL_SEQ_INST_SRCS  = $(SAIL_RISCV_MODEL_DIR)/riscv_insts_begin.sail $(SAIL_SEQ_INST)  $(SAIL_RISCV_MODEL_DIR)/riscv_insts_end.sail
+SAIL_RMEM_INST_SRCS = $(SAIL_RISCV_MODEL_DIR)/riscv_insts_begin.sail $(SAIL_RMEM_INST) $(SAIL_RISCV_MODEL_DIR)/riscv_insts_end.sail
 
 # System and platform sources
 SAIL_SYS_SRCS =  $(SAIL_RISCV_MODEL_DIR)/riscv_csr_map.sail
 SAIL_SYS_SRCS += $(SAIL_RISCV_MODEL_DIR)/riscv_next_regs.sail
 SAIL_SYS_SRCS += $(SAIL_CHERI_MODEL_DIR)/cheri_sys_exceptions.sail
+SAIL_SYS_SRCS += $(SAIL_RISCV_MODEL_DIR)/riscv_sync_exception.sail
 SAIL_SYS_SRCS += $(SAIL_RISCV_MODEL_DIR)/riscv_next_control.sail
 SAIL_SYS_SRCS += $(SAIL_RISCV_MODEL_DIR)/riscv_sys_control.sail
+SAIL_SYS_SRCS += $(SAIL_CHECK_SRCS)
 
 SAIL_RV32_VM_SRCS = $(SAIL_RISCV_MODEL_DIR)/riscv_vmem_sv32.sail \
                     $(SAIL_RISCV_MODEL_DIR)/riscv_vmem_rv32.sail
@@ -56,7 +58,8 @@ SAIL_REGS_SRCS = $(SAIL_CHERI_MODEL_DIR)/cheri_reg_type.sail \
                  $(SAIL_RISCV_MODEL_DIR)/riscv_regs.sail \
                  $(SAIL_RISCV_MODEL_DIR)/riscv_sys_regs.sail \
                  $(SAIL_CHERI_MODEL_DIR)/cheri_sys_regs.sail \
-                 $(SAIL_CHERI_MODEL_DIR)/cheri_regs.sail
+                 $(SAIL_CHERI_MODEL_DIR)/cheri_regs.sail \
+                 $(SAIL_CHERI_MODEL_DIR)/cheri_pc_access.sail
 
 SAIL_ARCH_SRCS = $(PRELUDE) \
                  $(SAIL_RISCV_MODEL_DIR)/riscv_types.sail \

--- a/src/cheri_addr_checks.sail
+++ b/src/cheri_addr_checks.sail
@@ -148,8 +148,3 @@ function ext_handle_data_check_error(err : ext_data_addr_error) -> unit = {
   let _ = raise_c2_exception6(capEx, regnum);
   ()
 }
-
-
-/* accessors for default architectural addresses, for use from within instructions */
-/* FIXME: these don't really belong in this file. */
-

--- a/src/cheri_addr_checks.sail
+++ b/src/cheri_addr_checks.sail
@@ -13,7 +13,7 @@ function raise_c2_exception6(capEx, regnum) =
       excinfo = (None() : option(xlenbits)),
       ext     = Some(cause)
     };
-    nextPC = handle_exception(cur_privilege, CTL_TRAP(t), PC);
+    set_next_pc(exception_handler(cur_privilege, CTL_TRAP(t), PC));
     false
   }
 
@@ -153,24 +153,3 @@ function ext_handle_data_check_error(err : ext_data_addr_error) -> unit = {
 /* accessors for default architectural addresses, for use from within instructions */
 /* FIXME: these don't really belong in this file. */
 
-/* FIXME: The asymmetry between get_next_pc and set_next_pc where one
- * returns the architectural PC but the other set the PCC-relative PC
- * is a bit weird. The way they are currently used it is correct but
- * we should either rename one of the functions or call set_next_pc
- * with the original target address instead of the munged one. - RNW.
- */
-
-val get_next_pc : unit -> xlenbits effect {rreg}
-function get_next_pc() =
-  nextPC - getCapBaseBits(PCC)
-
-val set_next_pc : xlenbits -> unit effect {wreg}
-function set_next_pc(pc) =
-  /* could check for internal errors here on invalid pc */
-  nextPC = pc
-
-val tick_pc : unit -> unit effect {rreg, wreg}
-function tick_pc() = {
-  PCC = nextPCC;
-  PC = nextPC
-}

--- a/src/cheri_pc_access.sail
+++ b/src/cheri_pc_access.sail
@@ -1,3 +1,5 @@
+/* accessors for default architectural addresses, for use from within instructions */
+
 /* FIXME: The asymmetry between get_next_pc and set_next_pc where one
  * returns the architectural PC but the other set the PCC-relative PC
  * is a bit weird. The way they are currently used it is correct but

--- a/src/cheri_pc_access.sail
+++ b/src/cheri_pc_access.sail
@@ -1,0 +1,21 @@
+/* FIXME: The asymmetry between get_next_pc and set_next_pc where one
+ * returns the architectural PC but the other set the PCC-relative PC
+ * is a bit weird. The way they are currently used it is correct but
+ * we should either rename one of the functions or call set_next_pc
+ * with the original target address instead of the munged one. - RNW.
+ */
+
+val get_next_pc : unit -> xlenbits effect {rreg}
+function get_next_pc() =
+  nextPC - getCapBaseBits(PCC)
+
+val set_next_pc : xlenbits -> unit effect {wreg}
+function set_next_pc(pc) =
+  /* could check for internal errors here on invalid pc */
+  nextPC = pc
+
+val tick_pc : unit -> unit effect {rreg, wreg}
+function tick_pc() = {
+  PCC = nextPCC;
+  PC = nextPC
+}


### PR DESCRIPTION
The main changes are due to cleaning up the exception handling functions in sail-riscv, which required some restructuring to sort out dependencies in the cheri model. These changes are with respect to the master-cleanup branch in sail-riscv.

