### PR TITLE
Remove all implicit casts in sail-cheri-riscv

### DIFF
--- a/src/cheri_cap_common.sail
+++ b/src/cheri_cap_common.sail
@@ -38,18 +38,18 @@ type CapAddrBits = bits(cap_addr_width)
 type CapLenBits  = bits(cap_len_width)
 
 function getCapHardPerms(cap) : Capability -> bits(12) =
-   (cap.permit_set_CID
-  @ cap.access_system_regs
-  @ cap.permit_unseal
-  @ cap.permit_ccall
-  @ cap.permit_seal
-  @ cap.permit_store_local_cap
-  @ cap.permit_store_cap
-  @ cap.permit_load_cap
-  @ cap.permit_store
-  @ cap.permit_load
-  @ cap.permit_execute
-  @ cap.global)
+   (bool_to_bits(cap.permit_set_CID)
+  @ bool_to_bits(cap.access_system_regs)
+  @ bool_to_bits(cap.permit_unseal)
+  @ bool_to_bits(cap.permit_ccall)
+  @ bool_to_bits(cap.permit_seal)
+  @ bool_to_bits(cap.permit_store_local_cap)
+  @ bool_to_bits(cap.permit_store_cap)
+  @ bool_to_bits(cap.permit_load_cap)
+  @ bool_to_bits(cap.permit_store)
+  @ bool_to_bits(cap.permit_load)
+  @ bool_to_bits(cap.permit_execute)
+  @ bool_to_bits(cap.global))
 
 /* Convert from capabilty struct to bits (no tag) */
 function capToBits(cap) : Capability -> CapBits = {
@@ -64,9 +64,9 @@ function capToBits(cap) : Capability -> CapBits = {
   return (cap.uperms
     @ getCapHardPerms(cap)
     @ cap.reserved
-    @ cap.flag_cap_mode
+    @ bool_to_bits(cap.flag_cap_mode)
     @ cap.otype
-    @ cap.internal_e
+    @ bool_to_bits(cap.internal_e)
     @ t_hi
     @ t_lo
     @ b_hi
@@ -135,7 +135,7 @@ function setCapBounds(cap, base, top) : (Capability, CapAddrBits, CapLenBits) ->
   let e = maxE - count_leading_zeros(length[cap_addr_width..mantissa_width - 1]);
   // Use use internal exponent if e is non-zero or if e is zero but
   // but the implied bit of length is not zero (denormal vs. normal case)
-  let ie = (e != 0) | length[mantissa_width - 2];
+  let ie = (e != 0) | length[mantissa_width - 2] == bitone;
 
   /* The non-ie e == 0 case is easy. It is exact so just extract relevant bits. */
   Bbits = truncate(base, mantissa_width);
@@ -167,13 +167,13 @@ function setCapBounds(cap, base, top) : (Capability, CapAddrBits, CapLenBits) ->
     /* Has the length overflowed? We chose e so that the top two bits of len would be 0b01,
        but either because of incrementing T or losing bits of base it might have grown. */
     len_ie = T_ie - B_ie;
-    if len_ie[mantissa_width - 4] then {
+    if len_ie[mantissa_width - 4] == bitone then {
       /* length overflow -- increment E by one and then recalculate
          T, B etc accordingly */
       incE = true;
 
-      lostSignificantBase = lostSignificantBase | B_ie[0];
-      lostSignificantTop  = lostSignificantTop | T_ie[0];
+      lostSignificantBase = lostSignificantBase | B_ie[0] == bitone;
+      lostSignificantTop  = lostSignificantTop | T_ie[0] == bitone;
 
       B_ie = truncate(base >> (e + 4), mantissa_width - 3);
       let incT : range(0,1) = if lostSignificantTop then 1 else 0;
@@ -196,31 +196,31 @@ function setCapPerms(cap, perms) : (Capability, bits(31)) -> Capability =
     { cap with
       uperms                 = truncate(perms[30..15], uperms_width),
       /* 14..12 reserved -- ignore */
-      permit_set_CID         = perms[11],
-      access_system_regs     = perms[10],
-      permit_unseal          = perms[9],
-      permit_ccall           = perms[8],
-      permit_seal            = perms[7],
-      permit_store_local_cap = perms[6],
-      permit_store_cap       = perms[5],
-      permit_load_cap        = perms[4],
-      permit_store           = perms[3],
-      permit_load            = perms[2],
-      permit_execute         = perms[1],
-      global                 = perms[0]
+      permit_set_CID         = bit_to_bool(perms[11]),
+      access_system_regs     = bit_to_bool(perms[10]),
+      permit_unseal          = bit_to_bool(perms[9]),
+      permit_ccall           = bit_to_bool(perms[8]),
+      permit_seal            = bit_to_bool(perms[7]),
+      permit_store_local_cap = bit_to_bool(perms[6]),
+      permit_store_cap       = bit_to_bool(perms[5]),
+      permit_load_cap        = bit_to_bool(perms[4]),
+      permit_store           = bit_to_bool(perms[3]),
+      permit_load            = bit_to_bool(perms[2]),
+      permit_execute         = bit_to_bool(perms[1]),
+      global                 = bit_to_bool(perms[0])
       }
 
 /*!
 Gets the architecture specific capability flags for given capability.
  */
 val getCapFlags : Capability -> CFlags
-function getCapFlags(cap) = cap.flag_cap_mode /* NB cast from bool to bits(1) */
+function getCapFlags(cap) = bool_to_bits(cap.flag_cap_mode)
 
 /*!
 THIS`(cap, flags)` sets the architecture specific capability flags on `cap` to `flags` and returns the result as new capability.
  */
 val setCapFlags : (Capability, CFlags) -> Capability
-function setCapFlags(cap, flags) = {cap with flag_cap_mode = flags[0]}
+function setCapFlags(cap, flags) = {cap with flag_cap_mode = bit_to_bool(flags[0])}
 
 function sealCap(cap, otyp) : (Capability, bits(24)) -> (bool, Capability) =
     (true, {cap with sealed=true, otype=truncate(otyp, otype_width)})

--- a/src/cheri_insts.sail
+++ b/src/cheri_insts.sail
@@ -92,14 +92,14 @@ function clause execute (CGetLen(rd, cb)) =
 function clause execute (CGetTag(rd, cb)) =
 {
   let capVal = readCapReg(cb);
-  X(rd) = EXTZ(capVal.tag);
+  X(rd) = EXTZ(bool_to_bits(capVal.tag));
   RETIRE_SUCCESS
 }
 
 function clause execute (CGetSealed(rd, cb)) =
 {
   let capVal = readCapReg(cb);
-  X(rd) = EXTZ(capVal.sealed);
+  X(rd) = EXTZ(bool_to_bits(capVal.sealed));
   RETIRE_SUCCESS
 }
 
@@ -156,7 +156,7 @@ function clause execute (CSetCause(rt)) =
 union clause ast = CSpecialRW : (regidx, regidx, regidx)
 function clause execute (CSpecialRW(cd, cs, idx)) =
 {
-  let (specialExists, ro, priv, needASR) : (bool, bool, Privilege, bool) = match idx {
+  let (specialExists, ro, priv, needASR) : (bool, bool, Privilege, bool) = match unsigned(idx) {
     0  => (true, true,  User, false),
     1  => (true, false, User, false),
     4 if haveNExt() => (true, false, User, true),
@@ -176,16 +176,16 @@ function clause execute (CSpecialRW(cd, cs, idx)) =
   if (not(specialExists)) then {
     handle_illegal();
     RETIRE_FAIL
-  } else if (ro & cs != 0) |
-     (cur_privilege <_u priv) |
+  } else if (ro & cs != 0b00000) |
+     (privLevel_to_bits(cur_privilege) <_u privLevel_to_bits(priv)) |
      (needASR & not(pcc_access_system_regs())) then {
     handle_cheri_cap_exception(CapEx_AccessSystemRegsViolation, 0b1 @ idx);
     RETIRE_FAIL
   } else {
     let cs_val = readCapReg(cs);
-    if (cd != 0) then {
+    if (cd != 0b00000) then {
       // read special cap
-      let special_val : Capability = match idx {
+      let special_val : Capability = match unsigned(idx) {
         0  => {
           let (success, pcc) = setCapAddr(PCC, PC);
           assert (success, "PCC with offset PC should always be representable");
@@ -208,9 +208,9 @@ function clause execute (CSpecialRW(cd, cs, idx)) =
       };
       writeCapReg(cd, special_val);
     };
-    if (cs != 0) then {
+    if (cs != 0b00000) then {
       // write special cap
-      match idx {
+      match unsigned(idx) {
         1  => DDC = cs_val,
         4  => UTCC = legalize_tcc(UTCC, cs_val),
         5  => UTDC = cs_val,
@@ -465,7 +465,7 @@ function clause execute (ClearRegs(regset, q, m)) =
     checkCP2usable();
   */
   foreach (i from 0 to 7)
-    if (m[i]) then
+    if m[i] == bitone then
       match regset {
         GPRegs => X(8 * unsigned(q) + i) = zeros(),
         FPRegs => () /* XXX no F regs yet */
@@ -847,7 +847,7 @@ function clause execute (CCall(cs, cb, 0b00001)) = /* selector=1 */
   } else if not(inCapBounds(cs_val, newPC, min_instruction_bytes())) then {
     handle_cheri_reg_exception(CapEx_LengthViolation, cs);
     RETIRE_FAIL
-  } else if newPC[1] & ~(haveRVC()) then {
+  } else if newPC[1] == bitone & ~(haveRVC()) then {
     handle_mem_exception(newPC,  E_Fetch_Addr_Align);
     RETIRE_FAIL
   } else {
@@ -881,7 +881,7 @@ function clause execute(CJALR(cd, cb)) =
   } else if not(inCapBounds(cb_val, newPC, min_instruction_bytes())) then {
     handle_cheri_reg_exception(CapEx_LengthViolation, cb);
     RETIRE_FAIL
-  } else if newPC[1] & ~(haveRVC()) then {
+  } else if newPC[1] == bitone & ~(haveRVC()) then {
     handle_mem_exception(newPC,  E_Fetch_Addr_Align);
     RETIRE_FAIL
   } else {

--- a/src/cheri_prelude_128.sail
+++ b/src/cheri_prelude_128.sail
@@ -140,7 +140,7 @@ let default_cap : Capability = struct {
 
 /* Convert from capabilty bits (128 bits with tag) to a more convenient struct. */
 function capBitsToCapability(t, c) : (bool, CapBits) -> Capability = {
-  internal_exponent : bool = c[90];
+  internal_exponent : bool = bit_to_bool(c[90]);
   otype : bits(18) = c[108..91];
   let sealed : bool = otype != ones();
   E : bits(6)  = zeros();
@@ -170,20 +170,20 @@ function capBitsToCapability(t, c) : (bool, CapBits) -> Capability = {
   return struct {
     tag                    = t,
     uperms                 = c[127..124],
-    permit_set_CID         = c[123],
-    access_system_regs     = c[122],
-    permit_unseal          = c[121],
-    permit_ccall           = c[120],
-    permit_seal            = c[119],
-    permit_store_local_cap = c[118],
-    permit_store_cap       = c[117],
-    permit_load_cap        = c[116],
-    permit_store           = c[115],
-    permit_load            = c[114],
-    permit_execute         = c[113],
-    global                 = c[112],
+    permit_set_CID         = bit_to_bool(c[123]),
+    access_system_regs     = bit_to_bool(c[122]),
+    permit_unseal          = bit_to_bool(c[121]),
+    permit_ccall           = bit_to_bool(c[120]),
+    permit_seal            = bit_to_bool(c[119]),
+    permit_store_local_cap = bit_to_bool(c[118]),
+    permit_store_cap       = bit_to_bool(c[117]),
+    permit_load_cap        = bit_to_bool(c[116]),
+    permit_store           = bit_to_bool(c[115]),
+    permit_load            = bit_to_bool(c[114]),
+    permit_execute         = bit_to_bool(c[113]),
+    global                 = bit_to_bool(c[112]),
     reserved               = c[111..110],
-    flag_cap_mode          = c[109],
+    flag_cap_mode          = bit_to_bool(c[109]),
     internal_e             = internal_exponent,
     E                      = E,
     sealed                 = sealed,

--- a/src/cheri_regs.sail
+++ b/src/cheri_regs.sail
@@ -1,8 +1,8 @@
 /* accessors for capability representation */
 
 /* reads a given capability register, or the null capability if the argument is zero. */
-val readCapReg : forall 'n, 0 <= 'n < 32. regno('n) -> regtype effect {rreg, escape}
-function readCapReg r = {
+val readCapReg_int : forall 'n, 0 <= 'n < 32. regno('n) -> regtype effect {rreg, escape}
+function readCapReg_int r = {
   match r {
     0  => zero_reg,
     1  => x1,
@@ -40,14 +40,24 @@ function readCapReg r = {
   }
 }
 
+function readCapReg_bits(r: bits(5)) -> regtype = readCapReg_int(unsigned(r))
+
+overload readCapReg = {readCapReg_bits, readCapReg_int}
+
 /* as per [readCapReg] but reads DDC instead of null when argument is zero. */
-val readCapRegDDC : forall 'n, 0 <= 'n < 32 . regno('n) -> Capability effect {rreg, escape}
-function readCapRegDDC(r) =
-  if r == 0 then DDC else readCapReg(r)
+val readCapRegDDC_int : forall 'n, 0 <= 'n < 32 . regno('n) -> Capability effect {rreg, escape}
+function readCapRegDDC_int(r) =
+  if r == 0 then DDC else readCapReg_int(r)
+
+val readCapRegDDC_bits : bits(5) -> Capability effect {rreg, escape}
+function readCapRegDDC_bits(r) =
+  if r == 0b00000 then DDC else readCapReg_bits(r)
+
+overload readCapRegDDC = {readCapRegDDC_bits, readCapRegDDC_int}
 
 /* writes a register with a capability value */
-val writeCapReg : forall 'n, 0 <= 'n < 32. (regno('n), regtype) -> unit effect {wreg, escape}
-function writeCapReg (r, v) = {
+val writeCapReg_int : forall 'n, 0 <= 'n < 32. (regno('n), regtype) -> unit effect {wreg, escape}
+function writeCapReg_int (r, v) = {
   match r {
     0  => (),
     1  => x1 = v,
@@ -89,6 +99,10 @@ function writeCapReg (r, v) = {
        print_reg("x" ^ string_of_int(r) ^ " <- " ^ RegStr(v));
   }
 }
+
+function writeCapReg_bits(r: bits(5), v: regtype) -> unit = writeCapReg_int(unsigned(r), v)
+
+overload writeCapReg = {writeCapReg_bits, writeCapReg_int}
 
 val ext_init_regs : unit -> unit effect {wreg}
 function ext_init_regs () = {
@@ -143,7 +157,7 @@ function ext_init_regs () = {
   x30 = null_cap;
   x31 = null_cap;
 
-  misa->X() = true;
+  misa->X() = 0b1;
 }
 
 /*!

--- a/src/cheri_step_ext.sail
+++ b/src/cheri_step_ext.sail
@@ -2,7 +2,7 @@
 
 val ext_init : unit -> unit effect {wreg}
 function ext_init () =
-  misa->X() = true
+  misa->X() = 0b1
 
 /* other hooks are not currently used. */
 function ext_fetch_hook(f : FetchResult) -> FetchResult = f

--- a/src/cheri_sys_regs.sail
+++ b/src/cheri_sys_regs.sail
@@ -95,7 +95,7 @@ function min_instruction_bytes () -> CapAddrInt = {
 
 function haveXcheri () -> bool =
   /* This is a necessary but not sufficient condition, but should do for now. */
-  misa.X() == true
+  misa.X() == 0b1
 
 
 function legalize_tcc(o : Capability, v : Capability) -> Capability = {


### PR DESCRIPTION
We removed all the implicit casting from sail-riscv, so this commit makes the corresponding changes here.

The bits(5) -> regidx cast is replaced by overloading the readCapReg/writeCapReg functions to take both bitvectors of length 5, and integer indices.