### PR TITLE
Bump sail-riscv and provide exception code hooks for CHERI with correct code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ SAIL_REGS_SRCS = $(SAIL_CHERI_MODEL_DIR)/cheri_reg_type.sail \
                  $(SAIL_CHERI_MODEL_DIR)/cheri_pc_access.sail
 
 SAIL_ARCH_SRCS = $(PRELUDE) \
+                 $(SAIL_RISCV_MODEL_DIR)/riscv_types_common.sail \
                  $(SAIL_CHERI_MODEL_DIR)/cheri_riscv_types.sail \
                  $(SAIL_RISCV_MODEL_DIR)/riscv_types.sail \
                  $(SAIL_REGS_SRCS) \
@@ -91,6 +92,7 @@ SAIL_ARCH_SRCS = $(PRELUDE) \
 SAIL_ARCH_RVFI_SRCS = \
                  $(PRELUDE) \
                  $(SAIL_RISCV_MODEL_DIR)/rvfi_dii.sail \
+                 $(SAIL_RISCV_MODEL_DIR)/riscv_types_common.sail \
                  $(SAIL_CHERI_MODEL_DIR)/cheri_riscv_types.sail \
                  $(SAIL_RISCV_MODEL_DIR)/riscv_types.sail \
                  $(SAIL_REGS_SRCS) \

--- a/src/cheri_riscv_types.sail
+++ b/src/cheri_riscv_types.sail
@@ -36,3 +36,15 @@ function ext_translate_exception(e : ext_ptw_error) -> ext_exc_type =
     AT_LOAD_CAP_ERR  => EXC_CHERI_VMEM_LOAD_CAP,
     AT_STORE_CAP_ERR => EXC_CHERI_VMEM_STORE_CAP
 }
+
+/* CHERI conversion of extension exceptions to bits */
+val ext_exc_type_to_bits : ext_exc_type -> exc_code
+function ext_exc_type_to_bits(e) = 0x1C
+
+/* CHERI conversion of extension exceptions to integers */
+val num_of_ext_exc_type : ext_exc_type -> {'n, (0 <= 'n < xlen). int('n)}
+function num_of_ext_exc_type(e) = 28
+
+/* CHERI conversion of extension exceptions to strings */
+val ext_exc_type_to_str : ext_exc_type -> string
+function ext_exc_type_to_str(e) = "cheri-exception"


### PR DESCRIPTION
This depends on https://github.com/rems-project/sail-riscv/pull/33 and thus needs a submodule bump as part of this commit once that pull request has been merged.