### PR TITLE
WIP: Add CRRL/CRAM

### DIFF
--- a/src/cheri_cap_common.sail
+++ b/src/cheri_cap_common.sail
@@ -329,3 +329,15 @@ function capToString (cap) = {
   concat_str(BitStr(getCapBaseBits(cap)),
   concat_str(" length:", len_str)))))))))))))
 }
+function getRepresentableAlignmentMask(len) : xlenbits -> xlenbits = {
+  let (exact, c) = setCapBounds(default_cap,  ones() - len, 0b0 @ ones(sizeof(xlen)));
+  let e = min(unsigned(c.E), maxE);
+  let e' = if c.internal_e then e + internal_exponent_take_bits else 0;
+  // FIXME: this won't compile ones(sizeof(xlen)-e') @ zeros(e')
+  ones(sizeof(xlen)) // @ zeros(1)
+}
+
+function getRepresentableLength(len) : xlenbits -> xlenbits = {
+  let m = getRepresentableAlignmentMask(len);
+  (len + ~(m)) & m
+}

--- a/src/cheri_insts.sail
+++ b/src/cheri_insts.sail
@@ -1132,7 +1132,7 @@ mapping clause assembly = CClearTag(cd, cs)  <-> "CClearTag"  ^ spc() ^ reg_name
 mapping clause assembly = CJALR(0b00000, cb) <-> "CJR"        ^ spc() ^ reg_name(cb)
 mapping clause assembly = CJALR(cd, cb)      <-> "CJALR"      ^ spc() ^ reg_name(cd) ^ sep() ^ reg_name(cb)
 
-mapping clause assembly = CRLL(rd, rs) <-> "CRRL" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs)
+mapping clause assembly = CRRL(rd, rs) <-> "CRRL" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs)
 mapping clause assembly = CRAM(rd, rs) <-> "CRAM" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs)
 
 mapping clause assembly = ClearRegs(GPRegs, q, m8) <-> "Clearq"   ^ spc() ^ hex_bits_2(q) ^ sep() ^ hex_bits_8(m8)

--- a/src/cheri_insts.sail
+++ b/src/cheri_insts.sail
@@ -571,44 +571,21 @@ function clause execute (CCopyType(cd, cb, ct)) =
   }
 }
 
-union clause ast = CCheckPerm : (regidx, regidx)
-function clause execute (CCheckPerm(cs, rt)) =
+
+union clause ast = CRRL : (regidx, regidx)
+function clause execute(CRRL(rd, rs)) =
 {
-  let cs_val = readCapReg(cs);
-  let cs_perms : xlenbits = EXTZ(getCapPerms(cs_val));
-  let rt_perms = X(rt);
-  if not (cs_val.tag) then {
-    handle_cheri_reg_exception(CapEx_TagViolation, cs);
-    RETIRE_FAIL
-  } else if (cs_perms & rt_perms) != rt_perms then {
-    handle_cheri_reg_exception(CapEx_UserDefViolation, cs);
-    RETIRE_FAIL
-  } else
-    RETIRE_SUCCESS
+  let len = X(rs);
+  X(rd) = getRepresentableLength(len);
+  RETIRE_SUCCESS
 }
 
-union clause ast = CCheckType : (regidx, regidx)
-function clause execute (CCheckType(cs, cb)) =
+union clause ast = CRAM : (regidx, regidx)
+function clause execute(CRAM(rd, rs)) =
 {
-  let cs_val = readCapReg(cs);
-  let cb_val = readCapReg(cb);
-  if not (cs_val.tag) then {
-    handle_cheri_reg_exception(CapEx_TagViolation, cs);
-    RETIRE_FAIL
-  } else if not (cb_val.tag) then {
-    handle_cheri_reg_exception(CapEx_TagViolation, cb);
-    RETIRE_FAIL
-  } else if not (cs_val.sealed) then {
-    handle_cheri_reg_exception(CapEx_SealViolation, cs);
-    RETIRE_FAIL
-  } else if not (cb_val.sealed) then {
-    handle_cheri_reg_exception(CapEx_SealViolation, cb);
-    RETIRE_FAIL
-  } else if cs_val.otype != cb_val.otype then {
-    handle_cheri_reg_exception(CapEx_TypeViolation, cs);
-    RETIRE_FAIL
-  } else
-    RETIRE_SUCCESS
+  let len = X(rs);
+  X(rd) = getRepresentableAlignmentMask(len);
+  RETIRE_SUCCESS
 }
 
 union clause ast = CCheckTag : (regidx)
@@ -1134,8 +1111,8 @@ mapping clause encdec = CMove(cd, cs)      if (haveXcheri()) <-> 0b1111111 @ 0b0
 mapping clause encdec = CClearTag(cd, cs)  if (haveXcheri()) <-> 0b1111111 @ 0b01011 @ cs @ 0b000 @ cd @ 0b1011011 if (haveXcheri())
 mapping clause encdec = CJALR(cd, cb)      if (haveXcheri()) <-> 0b1111111 @ 0b01100 @ cb @ 0b000 @ cd @ 0b1011011 if (haveXcheri())
 
-mapping clause encdec = CCheckPerm(cs, rt) if (haveXcheri()) <-> 0b1111111 @ 0b01000 @ rt @ 0b000 @ cs @ 0b1011011 if (haveXcheri())
-mapping clause encdec = CCheckType(cs, cb) if (haveXcheri()) <-> 0b1111111 @ 0b01001 @ cb @ 0b000 @ cs @ 0b1011011 if (haveXcheri())
+mapping clause encdec = CRRL(cs, rt) if (haveXcheri()) <-> 0b1111111 @ 0b01000 @ rt @ 0b000 @ cs @ 0b1011011 if (haveXcheri())
+mapping clause encdec = CRAM(cs, cb) if (haveXcheri()) <-> 0b1111111 @ 0b01001 @ cb @ 0b000 @ cs @ 0b1011011 if (haveXcheri())
 
 mapping clause encdec = ClearRegs(GPRegs, q, m3 @ m5) if (haveXcheri()) <-> 0b1111111 @ 0b01101 @ q : bits(2) @ m3 : bits(3) @ 0b000 @ m5 : regidx @ 0b1011011 if (haveXcheri())
 mapping clause encdec = ClearRegs(FPRegs, q, m3 @ m5) if (haveXcheri()) <-> 0b1111111 @ 0b10000 @ q : bits(2) @ m3 : bits(3) @ 0b000 @ m5 : regidx @ 0b1011011 if (haveXcheri())
@@ -1155,8 +1132,8 @@ mapping clause assembly = CClearTag(cd, cs)  <-> "CClearTag"  ^ spc() ^ reg_name
 mapping clause assembly = CJALR(0b00000, cb) <-> "CJR"        ^ spc() ^ reg_name(cb)
 mapping clause assembly = CJALR(cd, cb)      <-> "CJALR"      ^ spc() ^ reg_name(cd) ^ sep() ^ reg_name(cb)
 
-mapping clause assembly = CCheckPerm(cs, rt) <-> "CCheckPerm" ^ spc() ^ reg_name(cs) ^ sep() ^ reg_name(rt)
-mapping clause assembly = CCheckType(cs, cb) <-> "CCheckType" ^ spc() ^ reg_name(cs) ^ sep() ^ reg_name(cb)
+mapping clause assembly = CRLL(rd, rs) <-> "CRRL" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs)
+mapping clause assembly = CRAM(rd, rs) <-> "CRAM" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs)
 
 mapping clause assembly = ClearRegs(GPRegs, q, m8) <-> "Clearq"   ^ spc() ^ hex_bits_2(q) ^ sep() ^ hex_bits_8(m8)
 mapping clause assembly = ClearRegs(FPRegs, q, m8) <-> "FPClearq" ^ spc() ^ hex_bits_2(q) ^ sep() ^ hex_bits_8(m8)

--- a/src/cheri_prelude_128.sail
+++ b/src/cheri_prelude_128.sail
@@ -83,6 +83,7 @@ struct Capability = {
 
 /* Reset E and T calculated to make top 2**64. */
 let maxE = 52
+let internal_exponent_take_bits = 3
 let resetE = to_bits(6, maxE)
 let resetT = 0b01 @ 0x000 /* bit 12 set */
 

--- a/src/cheri_prelude_64.sail
+++ b/src/cheri_prelude_64.sail
@@ -84,6 +84,7 @@ struct Capability = {
 
 /* Reset E and T calculated to make top 2**32. */
 let maxE = 26
+let internal_exponent_take_bits = 3
 let resetE = to_bits(6, maxE)
 let resetT = 0b01000000 /* bit 6 set */
 


### PR DESCRIPTION
CCheckPerm/CCheckType have been removed and those opcodes are used for
CRRL/CRAM. This is mostly a copy of the MIPS implementation but I can't
get the sail typechecker to accept my changes.
Pushing this as a PR now so I don't forget