### PR TITLE
Code cleanup in preparation for sentries

### DIFF
--- a/src/cheri_cap_common.sail
+++ b/src/cheri_cap_common.sail
@@ -228,8 +228,8 @@ THIS`(cap, flags)` sets the architecture specific capability flags on `cap` to `
 val setCapFlags : (Capability, CFlags) -> Capability
 function setCapFlags(cap, flags) = {cap with flag_cap_mode = bit_to_bool(flags[0])}
 
-function sealCap(cap, otyp) : (Capability, bits(24)) -> (bool, Capability) =
-    (true, {cap with sealed=true, otype=truncate(otyp, otype_width)})
+function sealCap(cap, otyp) : (Capability, bits(otype_width)) -> (bool, Capability) =
+    (true, {cap with sealed=true, otype=otyp})
 
 function unsealCap(cap) : Capability -> Capability =
     {cap with sealed=false, otype=ones()}

--- a/src/cheri_cap_common.sail
+++ b/src/cheri_cap_common.sail
@@ -238,7 +238,7 @@ function sealCap(cap, otyp) : (Capability, bits(otype_width)) -> (bool, Capabili
     (true, {cap with sealed=true, otype=otyp})
 
 function unsealCap(cap) : Capability -> Capability =
-    {cap with sealed=false, otype=ones()}
+    {cap with sealed=false, otype=to_bits(otype_width, otype_unsealed)}
 
 function getCapBaseBits(c) : Capability -> CapAddrBits =
     let (base, _) = getCapBoundsBits(c) in

--- a/src/cheri_cap_common.sail
+++ b/src/cheri_cap_common.sail
@@ -228,6 +228,12 @@ THIS`(cap, flags)` sets the architecture specific capability flags on `cap` to `
 val setCapFlags : (Capability, CFlags) -> Capability
 function setCapFlags(cap, flags) = {cap with flag_cap_mode = bit_to_bool(flags[0])}
 
+/*! Tests whether the capability has a reserved otype (larger than max_otype).
+    Note that this includes both sealed (e.g. sentry) and unsealed (all ones)
+    otypes. */
+val hasReservedOType : Capability -> bool
+function hasReservedOType(cap) = unsigned(cap.otype) > max_otype
+
 function sealCap(cap, otyp) : (Capability, bits(otype_width)) -> (bool, Capability) =
     (true, {cap with sealed=true, otype=otyp})
 
@@ -350,7 +356,7 @@ function capToString (cap) = {
   let len = getCapLength(cap);
   let len_str = BitStr(to_bits(cap_len_width + 3, len));
   /* Print architectural type which is -1 for unsealed caps */
-  let otype64 : CapAddrBits = if cap.sealed then EXTZ(cap.otype) else ones();
+  let otype64 : CapAddrBits = if hasReservedOType(cap) then EXTS(cap.otype) else EXTZ(cap.otype);
   concat_str(" t:",
   concat_str(if cap.tag then "1" else "0",
   concat_str(" s:",

--- a/src/cheri_insts.sail
+++ b/src/cheri_insts.sail
@@ -830,7 +830,7 @@ function clause execute(CJALR(cd, cb)) =
     nextPC  = newPC;
     nextPCC = cb_val;
     RETIRE_SUCCESS
-  };
+  }
 }
 
 val handle_load_data_via_cap : (regidx, capreg_idx, Capability, xlenbits, bool, word_width) -> Retired effect {escape, rmem, rmemt, rreg, wmv, wmvt, wreg}

--- a/src/cheri_insts.sail
+++ b/src/cheri_insts.sail
@@ -673,7 +673,7 @@ function clause execute (CCSeal(cd, cs, ct)) =
   if not (cs_val.tag) then {
     handle_cheri_reg_exception(CapEx_TagViolation, cs);
     RETIRE_FAIL
-  } else if not (ct_val.tag) | (getCapCursor(ct_val) == MAX_ADDR) then {
+  } else if not (ct_val.tag) | (getCapCursor(ct_val) == otype_unsealed) then {
     writeCapReg(cd, cs_val);
     RETIRE_SUCCESS
   } else if cs_val.sealed then {

--- a/src/cheri_insts.sail
+++ b/src/cheri_insts.sail
@@ -61,9 +61,9 @@ function clause execute (CGetFlags(rd, cb)) =
 function clause execute (CGetType(rd, cb)) =
 {
   let capVal = readCapReg(cb);
-  X(rd) = if   capVal.sealed
-          then EXTZ(capVal.otype)
-          else ones();
+  X(rd) = if   hasReservedOType(capVal)
+          then EXTS(capVal.otype)
+          else EXTZ(capVal.otype);
   RETIRE_SUCCESS
 }
 
@@ -552,21 +552,19 @@ function clause execute (CCopyType(cd, cb, ct)) =
   } else if cb_val.sealed then {
     handle_cheri_reg_exception(CapEx_SealViolation, cb);
     RETIRE_FAIL
-  } else if ct_val.sealed then {
-    if ct_otype < cb_base then {
-      handle_cheri_reg_exception(CapEx_LengthViolation, cb);
-      RETIRE_FAIL
-    } else if ct_otype >= cb_top then {
-      handle_cheri_reg_exception(CapEx_LengthViolation, cb);
-      RETIRE_FAIL
-    } else {
-      let (success, cap) = setCapOffset(cb_val, to_bits(cap_addr_width, ct_otype - cb_base));
-      assert(success, "CopyType: offset is in bounds so should be representable");
-      writeCapReg(cd, cap);
-      RETIRE_SUCCESS
-    }
+  } else if hasReservedOType(ct_val) then {
+    writeCapReg(cd, int_to_cap(EXTS(ct_val.otype)));
+    RETIRE_SUCCESS
+  } else if ct_otype < cb_base then {
+    handle_cheri_reg_exception(CapEx_LengthViolation, cb);
+    RETIRE_FAIL
+  } else if ct_otype >= cb_top then {
+    handle_cheri_reg_exception(CapEx_LengthViolation, cb);
+    RETIRE_FAIL
   } else {
-    writeCapReg(cd, int_to_cap(ones()));
+    let (success, cap) = setCapOffset(cb_val, to_bits(cap_addr_width, ct_otype - cb_base));
+    assert(success, "CopyType: offset is in bounds so should be representable");
+    writeCapReg(cd, cap);
     RETIRE_SUCCESS
   }
 }
@@ -727,6 +725,9 @@ function clause execute (CUnseal(cd, cs, ct)) =
   } else if ct_val.sealed then {
     handle_cheri_reg_exception(CapEx_SealViolation, ct);
     RETIRE_FAIL
+  } else if hasReservedOType(cs_val) then {
+    handle_cheri_reg_exception(CapEx_TypeViolation, ct);
+    RETIRE_FAIL
   } else if ct_cursor != unsigned(cs_val.otype) then {
     handle_cheri_reg_exception(CapEx_TypeViolation, ct);
     RETIRE_FAIL
@@ -760,10 +761,10 @@ function clause execute (CCall(cs, cb)) =
   } else if not (cb_val.tag) then {
     handle_cheri_reg_exception(CapEx_TagViolation, cb);
     RETIRE_FAIL
-  } else if not (cs_val.sealed) then {
+  } else if hasReservedOType(cs_val) then {
     handle_cheri_reg_exception(CapEx_SealViolation, cs);
     RETIRE_FAIL
-  } else if not (cb_val.sealed) then {
+  } else if hasReservedOType(cb_val) then {
     handle_cheri_reg_exception(CapEx_SealViolation, cb);
     RETIRE_FAIL
   } else if cs_val.otype != cb_val.otype then {

--- a/src/cheri_insts.sail
+++ b/src/cheri_insts.sail
@@ -654,7 +654,7 @@ function clause execute (CSeal(cd, cs, ct)) =
     handle_cheri_reg_exception(CapEx_LengthViolation, ct);
     RETIRE_FAIL
   } else {
-    let (success, newCap) = sealCap(cs_val, to_bits(24, ct_cursor));
+    let (success, newCap) = sealCap(cs_val, to_bits(otype_width, ct_cursor));
     if not (success) then {
       handle_cheri_reg_exception(CapEx_InexactBounds, cs);
       RETIRE_FAIL
@@ -697,7 +697,7 @@ function clause execute (CCSeal(cd, cs, ct)) =
     handle_cheri_reg_exception(CapEx_LengthViolation, ct);
     RETIRE_FAIL
   } else {
-    let (success, newCap) = sealCap(cs_val, to_bits(24, ct_cursor));
+    let (success, newCap) = sealCap(cs_val, to_bits(otype_width, ct_cursor));
     if not (success) then {
       handle_cheri_reg_exception(CapEx_InexactBounds, cs);
       RETIRE_FAIL

--- a/src/cheri_prelude_128.sail
+++ b/src/cheri_prelude_128.sail
@@ -36,10 +36,12 @@
 type cap_size : Int = 16
 let cap_size = sizeof(cap_size)
 let log2_cap_size = 4
-type CapBits = bits(8*cap_size)
+type CapBits = bits(8 * cap_size)
 /* width of otype field in bits */
-let otype_width = 18
-let uperms_width = 4
+type otype_width : Int = 18
+let otype_width = sizeof(otype_width)
+type uperms_width : Int = 4
+let uperms_width = sizeof(uperms_width)
 type cap_addr_width : Int = xlen
 let  cap_addr_width = sizeof(cap_addr_width)
 type cap_len_width : Int = cap_addr_width + 1
@@ -57,7 +59,7 @@ type CapLen = range(0, 2 ^ 65) /* XXX sail can't handle if this is expressed as 
  */
 struct Capability = {
   tag                    : bool    ,
-  uperms                 : bits(4) ,
+  uperms                 : bits(uperms_width) ,
   permit_set_CID         : bool    ,
   access_system_regs     : bool    ,
   permit_unseal          : bool    ,
@@ -75,10 +77,10 @@ struct Capability = {
   internal_e             : bool    ,
   E                      : bits(6) ,
   sealed                 : bool    ,
-  B                      : bits(14),
-  T                      : bits(14),
-  otype                  : bits(18),
-  address                : bits(64)
+  B                      : bits(mantissa_width),
+  T                      : bits(mantissa_width),
+  otype                  : bits(otype_width),
+  address                : bits(cap_addr_width)
 }
 
 /* Reset E and T calculated to make top 2**64. */

--- a/src/cheri_prelude_128.sail
+++ b/src/cheri_prelude_128.sail
@@ -111,7 +111,7 @@ let null_cap : Capability = struct {
   sealed                 = false,
   B                      = zeros(),
   T                      = resetT,
-  otype                  = ones(),
+  otype                  = to_bits(otype_width, otype_unsealed),
   address                = zeros()
 }
 
@@ -137,7 +137,7 @@ let default_cap : Capability = struct {
   sealed                 = false,
   B                      = zeros(),
   T                      = resetT,
-  otype                  = ones(),
+  otype                  = to_bits(otype_width, otype_unsealed),
   address                = zeros()
 }
 
@@ -145,7 +145,7 @@ let default_cap : Capability = struct {
 function capBitsToCapability(t, c) : (bool, CapBits) -> Capability = {
   internal_exponent : bool = bit_to_bool(c[90]);
   otype : bits(18) = c[108..91];
-  let sealed : bool = otype != ones();
+  let sealed : bool = otype != to_bits(otype_width, otype_unsealed);
   E : bits(6)  = zeros();
   Bs : bits(14) = zeros();
   T : bits(12) = zeros();

--- a/src/cheri_prelude_64.sail
+++ b/src/cheri_prelude_64.sail
@@ -111,7 +111,7 @@ let null_cap : Capability = struct {
   sealed                 = false,
   B                      = zeros(),
   T                      = resetT,
-  otype                  = ones(),
+  otype                  = to_bits(otype_width, otype_unsealed),
   address                = zeros()
 }
 
@@ -137,7 +137,7 @@ let default_cap : Capability = struct {
   sealed                 = false,
   B                      = zeros(),
   T                      = resetT,
-  otype                  = ones(),
+  otype                  = to_bits(otype_width, otype_unsealed),
   address                = zeros()
 }
 
@@ -145,7 +145,7 @@ let default_cap : Capability = struct {
 function capBitsToCapability(t, c) : (bool, CapBits) -> Capability = {
   internal_exponent : bool = bit_to_bool(c[46]);
   otype : bits(4) = c[50..47];
-  let sealed : bool = otype != ones();
+  let sealed : bool = otype != to_bits(otype_width, otype_unsealed);
   E : bits(6)  = zeros();
   Bs : bits(8) = zeros();
   T : bits(6) = zeros();

--- a/src/cheri_prelude_64.sail
+++ b/src/cheri_prelude_64.sail
@@ -46,11 +46,12 @@ type cap_addr_width : Int = xlen
 let  cap_addr_width = sizeof(cap_addr_width)
 type cap_len_width : Int = xlen + 1
 let  cap_len_width  = sizeof(cap_len_width)
+type mantissa_width : Int = 8
+let mantissa_width = sizeof(mantissa_width)
+
 let MAX_ADDR = MAX(cap_addr_width)
 type CapAddrInt = range(0, (2 ^ cap_addr_width) - 1)
 type CapLen = range(0, 2 ^ 33) /* XXX sail can't handle if this is expressed as cap_len_width */
-type mantissa_width : Int = 8
-let mantissa_width = sizeof(mantissa_width)
 
 /* A partially decompressed version of a capability -- E, B, T,
  * lenMSB, sealed and otype fields are not present in all formats and are

--- a/src/cheri_properties.sail
+++ b/src/cheri_properties.sail
@@ -53,7 +53,7 @@ function encodableCap(c) : Capability -> bool =
   let Tie = truncate(c.T, internal_exponent_take_bits) in
   let Zie = zeros(internal_exponent_take_bits) in
   let bot_correct = (if c.internal_e then Bie == Zie & Tie == Zie else true) in
-  let sealed_correct = (c.sealed == (c.otype != ones())) in
+  let sealed_correct = (c.sealed == (c.otype != to_bits(otype_width, otype_unsealed))) in
   top_correct & bot_correct & ie_correct & sealed_correct
 
 /* A Capability is encodable iff the back-and-forth conversion to and

--- a/src/cheri_properties.sail
+++ b/src/cheri_properties.sail
@@ -78,7 +78,7 @@ function propSetBoundsEncodable(c, reqBase, reqTop) : (Capability, CapAddrBits, 
 
 /* Sealing with a valid object type preserves encodability */
 $property
-function propSealEncodable(c, otype) : (Capability, bits(24)) -> bool =
+function propSealEncodable(c, otype) : (Capability, bits(otype_width)) -> bool =
   let (_, c') = sealCap(c, otype) in
   let validType = (unsigned(otype) <= max_otype) in
   (encodableCap(c) & validType) --> encodableCap(c')

--- a/src/cheri_sys_exceptions.sail
+++ b/src/cheri_sys_exceptions.sail
@@ -80,11 +80,13 @@ val prepare_xret_target : (Privilege) -> xlenbits effect {rreg, wreg}
 function prepare_xret_target(p) = {
   /* Similar to prepare_trap_vector above we need to return the absolute address
      destined for PC, rather than the offset (architecutral PC) */
-  match p {
-    Machine    => {nextPCC = MEPCC; MEPCC.address},
-    Supervisor => {nextPCC = SEPCC; SEPCC.address},
-    User       => {nextPCC = UEPCC; UEPCC.address}
-  }
+  let epcc : Capability = match p {
+                            Machine    => MEPCC,
+                            Supervisor => SEPCC,
+                            User       => UEPCC
+                          };
+  nextPCC = epcc;
+  epcc.address
 }
 
 /* other trap-related CSRs */

--- a/src/cheri_sys_exceptions.sail
+++ b/src/cheri_sys_exceptions.sail
@@ -51,8 +51,8 @@ function prepare_trap_vector(p : Privilege, c : Mcause) -> xlenbits = {
      we want the absolute address to insert in PC. The bottom two bits (mode) should 
      be the same because we enforce aligned tcc base. */
   match tvec_addr(Mk_Mtvec(tcc.address), c) { 
-    Some(epc) => { nextPCC = tcc; epc },
-    None()    => internal_error("Invalid tvec mode")
+    Some(addr) => { nextPCC = tcc; addr },
+    None()     => internal_error("Invalid tvec mode")
   }
 }
 

--- a/src/cheri_sys_exceptions.sail
+++ b/src/cheri_sys_exceptions.sail
@@ -13,8 +13,7 @@ function handle_trap_extension(p : Privilege, pc : xlenbits, ccause : option(che
       /* XXX should legalize pc here? */
       let (representable, mepcc) = setCapAddr(PCC, pc);
       assert(representable, "mepcc should always be representable");
-      MEPCC   = mepcc;
-      nextPCC = MTCC
+      MEPCC   = mepcc
     },
     Supervisor => {
       match ccause {
@@ -25,8 +24,7 @@ function handle_trap_extension(p : Privilege, pc : xlenbits, ccause : option(che
       /* XXX should legalize pc here? */
       let (representable, sepcc) = setCapAddr(PCC, pc);
       assert(representable, "sepcc should always be representable");
-      SEPCC   = sepcc;
-      nextPCC = STCC
+      SEPCC   = sepcc
     },
     User => {
       match ccause {
@@ -37,8 +35,7 @@ function handle_trap_extension(p : Privilege, pc : xlenbits, ccause : option(che
       /* XXX should legalize pc here? */
       let (representable, uepcc) = setCapAddr(PCC, pc);
       assert(representable, "uepcc should always be representable");
-      UEPCC   = uepcc;
-      nextPCC = UTCC
+      UEPCC   = uepcc
     }
   }
 }

--- a/src/cheri_types.sail
+++ b/src/cheri_types.sail
@@ -36,6 +36,7 @@ type num_flags_t : Int = 1
 type CFlags = bits(num_flags_t)
 let num_flags = sizeof(num_flags_t)
 let reserved_otypes = 4
+let otype_unsealed = -1
 
 enum CPtrCmpOp = {
   CEQ,


### PR DESCRIPTION
These should all be NFCs. Further work will be needed to support putting sentries in xEPCC and not immediately untagging them due to legalisation, and likely with changes to sail-riscv too as currently prepare_xret_target's return value is masked, whereas it would be helpful for the function itself to have control over/knowledge of the masking in order to determine whether a sealed cap is being modified. We also need to stop legalising CSR/SCRs at write-time and move to the correct read-time legalisation, which already can yield observable differences in edge cases even without CHERI.