### PR TITLE
Refactor PTE extension logic

### DIFF
--- a/src/cheri_insts.sail
+++ b/src/cheri_insts.sail
@@ -909,7 +909,7 @@ function handle_load_cap_via_cap(rd, cs, cap_val, vaddrBits) = {
       let c = mem_read_cap(addr, aq, rl, false);
       match c {
         MemValue(v) => {
-          let cr = if ptw_info == PTW_LOAD_CAP_ERR
+          let cr = if   ptw_info.ptw_lc_mod == PTW_LCM_CLR
                    then {v with tag = false} /* strip the tag */
                    else {v with tag = v.tag & cap_val.permit_load_cap};
           writeCapReg(rd, cr);
@@ -1007,7 +1007,7 @@ if not(cap_val.tag) then {
       let c = mem_read_cap(addr, aq, rl, false);
       match c {
         MemValue(v) => {
-          let cr = if   ptw_info == PTW_LOAD_CAP_ERR
+          let cr = if   ptw_info.ptw_lc_mod == PTW_LCM_CLR
                    then {v with tag = false} /* strip the tag */
                    else {
                      /* the Sail model currently reserves virtual addresses */

--- a/src/cheri_pte.sail
+++ b/src/cheri_pte.sail
@@ -71,37 +71,24 @@ function checkPTEPermission(ac : AccessType(ext_access_type), priv : Privilege, 
   };
 
   let e = Mk_Ext_PTE_Bits(ext);
-  let (succ, pte_chk) : (bool, pte_check) =
+  let lcav = if e.LoadCap()  == 0b1 then PTW_LCM_OK else PTW_LCM_CLR;
+  let scav = if e.StoreCap() == 0b1 then PTW_SCM_OK else PTW_SCM_TRAP;
+  let (succ, ext_ptw') : (bool, ext_ptw) =
   match (base_succ, ac) {
     /* Base translation exceptions take priority over CHERI exceptions */
-    (false, _)               => (false, PTE_CAP_OK),
+    (false, _)               => (false, init_ext_ptw),
 
-    (true,  Read(Cap))       => if   e.LoadCap() == 0b1
-                                then (true, PTE_CAP_OK)
-                                /* Allow the address translation to proceed, but mark for tag stripping */
-                                else (true, PTE_LOAD_CAP_ERR),
+    (true,  Read(Cap))       => (true, ext_ptw_join_lcm(ext_ptw, lcav)),
+    (true,  Write(Cap))      => (true, ext_ptw_join_scm(ext_ptw, scav)),
+    (true,  ReadWrite(Cap))  => (true, ext_ptw_join_scm(ext_ptw_join_lcm(ext_ptw, lcav), scav)),
 
-    (true,  Write(Cap))      => if   e.StoreCap() == 0b1
-                                then (true, PTE_CAP_OK)
-                                /* Do not allow the address translation to proceed */
-                                else (false, PTE_STORE_CAP_ERR),
-
-    (true,  ReadWrite(Cap))  => if   e.StoreCap() == 0b1 & e.LoadCap() == 0b1
-                                then (true, PTE_CAP_OK)
-                                else if e.StoreCap() == 0b0
-                                /* Do not allow the address translation to proceed */
-                                then (false, PTE_STORE_CAP_ERR)
-                                /* Allow the address translation to proceed, but mark for tag stripping */
-                                else (true, PTE_LOAD_CAP_ERR),
-
-    (true,  Read(Data))      => (true, PTE_CAP_OK),
-    (true,  Write(Data))     => (true, PTE_CAP_OK),
-    (true,  ReadWrite(Data)) => (true, PTE_CAP_OK),
-    (true,  Execute())       => (true, PTE_CAP_OK)
+    (true,  Read(Data))      => (true, ext_ptw),
+    (true,  Write(Data))     => (true, ext_ptw),
+    (true,  ReadWrite(Data)) => (true, ext_ptw),
+    (true,  Execute())       => (true, ext_ptw)
   };
 
-  let ext_ptw = ext_accum_ptw_result(ext_ptw, pte_chk);
-  if succ then PTE_Check_Success(ext_ptw) else PTE_Check_Failure(ext_ptw)
+  if succ then PTE_Check_Success(ext_ptw') else PTE_Check_Failure(ext_ptw')
 }
 
 function update_PTE_Bits(p : PTE_Bits, a : AccessType(ext_access_type), ext : extPte) -> option((PTE_Bits, extPte)) = {

--- a/src/cheri_ptw.sail
+++ b/src/cheri_ptw.sail
@@ -24,21 +24,43 @@ function ptw_error_to_str(e) =
 
 overload to_str = {ptw_error_to_str}
 
+/*
+ * Produce the PTW_Error for PTE_Check_Failure-s arising from
+ * checkPTEPermission calls.
+ *
+ * We analyse only the store-side component of ext_ptw here.  The MMU/PTW logic
+ * does not see into the data path, and so load-side responses, including
+ * traps, must be handled by the instruction that initiated the translation by
+ * considering the ext_ptw result provided by the MMU/PTW.
+ */
 function ext_get_ptw_error(ext_ptw : ext_ptw) -> PTW_Error =
-  match (ext_ptw) {
-    PTW_CAP_OK        => PTW_No_Permission(),
-    PTW_LOAD_CAP_ERR  => PTW_Ext_Error(AT_CAP_ERR),
-    PTW_STORE_CAP_ERR => PTW_Ext_Error(AT_CAP_ERR)
+  match (ext_ptw.ptw_sc_mod) {
+    PTW_SCM_TRAP => PTW_Ext_Error(AT_CAP_ERR),
+    PTW_SCM_OK   => PTW_No_Permission()
   }
 
 /* conversion of these translation/PTW failures into architectural exceptions */
 function translationException(a : AccessType(ext_access_type), f : PTW_Error) -> ExceptionType = {
   let e : ExceptionType =
   match (a, f) {
-    /* First handle the vmem extension errors */
-    (ReadWrite(Cap), PTW_Ext_Error(AT_CAP_ERR)) => E_Extension(EXC_SAMO_CAP_PAGE_FAULT),
-    (Read(Cap), PTW_Ext_Error(AT_CAP_ERR))      => E_Extension(EXC_LOAD_CAP_PAGE_FAULT),
+
+    /* Tag-asserting stores can raise CHERI page faults. */
     (Write(Cap), PTW_Ext_Error(AT_CAP_ERR))     => E_Extension(EXC_SAMO_CAP_PAGE_FAULT),
+
+    /*
+     * XXX ReadWrite(Cap) does not provide enough information to distinguish
+     * between a tag-clearing store and tag-asserting store in the presence of
+     * a tag-capable load, or a tag-asserting store in the case of a
+     * tag-incapable load.  (That is, it only clearly distinguishes a
+     * tag-incapable load with a tag-clearing store from every other option.)
+     * Groundwork for fixing this exists in the sail RISC-V model, but we have
+     * not yet caught up to that point.  Fortunately, we don't actually have
+     * amoswap.c yet, so this is not observably wrong.
+     */
+    (ReadWrite(Cap), PTW_Ext_Error(AT_CAP_ERR)) => E_Extension(EXC_SAMO_CAP_PAGE_FAULT),
+
+    /* No other operations should raise CHERI-specific page faults */
+    (_, PTW_Ext_Error(_)) => internal_error("Unexpected PTW Extension Error"),
 
     /* For other exceptions, Cap accesses fault similar to Data accesses below. */
     (ReadWrite(Cap), PTW_Access())  => E_SAMO_Access_Fault(),

--- a/src/cheri_riscv_types.sail
+++ b/src/cheri_riscv_types.sail
@@ -1,27 +1,55 @@
-/* Extension for CHERI PTE checks */
-enum pte_check = {PTE_CAP_OK, PTE_LOAD_CAP_ERR, PTE_STORE_CAP_ERR}
+/*
+ * Extension for CHERI page table walker
+ *
+ * We are going to carry around a summary of the PTW walk for data-dependent
+ * (well, tag-dependent) behaviors by the instructions.  The elimination of
+ * ext_ptw values is, sadly, diffuse, across the PTW logic itself
+ * (ext_get_ptw_error) and the various instructions' analysis of load-side
+ * caveats (since the PTW does not have visibility into the data path).
+ */
 
-/* Extension for CHERI page-table-walks */
+enum ext_ptw_lcm = {
+  /* Tags flow as might be expected */
+  PTW_LCM_OK,
 
-enum ext_ptw = {PTW_CAP_OK, PTW_LOAD_CAP_ERR, PTW_STORE_CAP_ERR}
+  /* PTE settings require clearing tags */
+  PTW_LCM_CLR
+}
 
-let init_ext_ptw : ext_ptw = PTW_CAP_OK /* initial value of the PTW accumulator */
+enum ext_ptw_scm = {
+  /* Tag stores are permitted */
+  PTW_SCM_OK,
 
-/* Default accumulation of PTE check extensions into PTW accumulator */
-function ext_accum_ptw_result(ptw : ext_ptw, pte : pte_check) -> ext_ptw =
-  match (ptw, pte) {
-    (PTW_CAP_OK, PTE_CAP_OK)        => PTW_CAP_OK,
-    (PTW_CAP_OK, PTE_LOAD_CAP_ERR)  => PTW_LOAD_CAP_ERR,
-    (PTW_CAP_OK, PTE_STORE_CAP_ERR) => PTW_STORE_CAP_ERR,
+  /* Tag-asserting stores trap */
+  PTW_SCM_TRAP
+}
 
-    /* CHECK ME: The below prioritizes store exceptions over load tag stripping. */
+struct ext_ptw = {
+  ptw_lc_mod : ext_ptw_lcm,
+  ptw_sc_mod : ext_ptw_scm
+}
 
-    (PTW_LOAD_CAP_ERR, PTE_CAP_OK)        => PTW_LOAD_CAP_ERR,
-    (PTW_LOAD_CAP_ERR, PTE_LOAD_CAP_ERR)  => PTW_LOAD_CAP_ERR,
-    (PTW_LOAD_CAP_ERR, PTE_STORE_CAP_ERR) => PTW_STORE_CAP_ERR,
-
-    (PTW_STORE_CAP_ERR, _ )               => PTW_STORE_CAP_ERR
+function ext_ptw_join_lcm(e : ext_ptw, l : ext_ptw_lcm) -> ext_ptw =
+  { e with ptw_lc_mod =
+      match l {
+        PTW_LCM_OK => e.ptw_lc_mod,
+        PTW_LCM_CLR => l
+      }
   }
+
+function ext_ptw_join_scm(e : ext_ptw, s : ext_ptw_scm) -> ext_ptw =
+  { e with ptw_sc_mod =
+      match s {
+        PTW_SCM_OK => e.ptw_sc_mod,
+        PTW_SCM_TRAP => s
+      }
+  }
+
+/* initial value of the PTW accumulator */
+let init_ext_ptw : ext_ptw = struct {
+  ptw_lc_mod = PTW_LCM_OK,
+  ptw_sc_mod = PTW_SCM_OK
+}
 
 /* Address translation errors */
 enum ext_ptw_error = {AT_CAP_ERR}

--- a/src/cheri_vmem_types.sail
+++ b/src/cheri_vmem_types.sail
@@ -1,5 +1,17 @@
 // Specialize the accesstype for memory
 
+/*
+ * We can indicate to the MMU/PTW whether a memory operation conveys a
+ * certainly cleared tag (Data) or a possibly asserted tag (Cap).  As the
+ * MMU/PTW does not have access to the data paths, there is some possibility of
+ * confusion.  Care must be taken to ensure that transactions marked as Data
+ * are not used to convey asserted tags.  At the same time, tag-capable but
+ * -clearing instructions should indicate that they are performing Data, not
+ * Cap, operations to avoid spuriously raising CHERI page faults.  That is, if
+ * reading a capability from memory but about to clear its tag, prefer to
+ * indicate a Read(Data) to the MMU.  Similarly, if writing a capability with
+ * known clear tag, indicate a Write(Data).
+ */
 enum ext_access_type = {
   Data,
   Cap


### PR DESCRIPTION
Notably, ext_ptw is now a struct (a pair, at the moment) rather than a
single enumerated value.  This should make it easier to do the
CLG/capdirty tracking bits.

No functional change intended.