### PR TITLE
Fix PTE exceptions

### DIFF
--- a/src/cheri_insts.sail
+++ b/src/cheri_insts.sail
@@ -1206,7 +1206,7 @@ function handle_store_cap_via_cap(rs, cs, cap_val, vaddrBits) = {
   } else if not(is_aligned_addr(vaddrBits, cap_size)) then {
     handle_mem_exception(vaddrBits, E_SAMO_Addr_Align());
     RETIRE_FAIL
-  } else match translateAddr(vaddrBits, Write(Cap)) {
+  } else match translateAddr(vaddrBits, Write(if rs_val.tag then Cap else Data)) {
     TR_Failure(E_Extension(EXC_CHERI_VMEM_STORE_CAP), _) => {
       handle_cheri_cap_exception(CapEx_TLBNoStoreCap, cs);
       RETIRE_FAIL
@@ -1354,7 +1354,7 @@ function handle_store_cond_cap_via_cap(cs2, cs, cap_val, vaddrBits) = {
     cancel_reservation();
     RETIRE_SUCCESS
   } else {
-    match translateAddr(vaddrBits, Write(Cap)) {
+    match translateAddr(vaddrBits, Write(if cs2_val.tag then Cap else Data)) {
       TR_Failure(E_Extension(EXC_CHERI_VMEM_STORE_CAP), _) => {
         handle_cheri_cap_exception(CapEx_TLBNoStoreCap, cs);
         RETIRE_FAIL

--- a/src/cheri_insts.sail
+++ b/src/cheri_insts.sail
@@ -1207,11 +1207,6 @@ function handle_store_cap_via_cap(rs, cs, cap_val, vaddrBits) = {
     handle_mem_exception(vaddrBits, E_SAMO_Addr_Align());
     RETIRE_FAIL
   } else match translateAddr(vaddrBits, Write(if rs_val.tag then Cap else Data)) {
-    TR_Failure(E_Extension(EXC_CHERI_VMEM_STORE_CAP), _) => {
-      handle_cheri_cap_exception(CapEx_TLBNoStoreCap, cs);
-      RETIRE_FAIL
-    },
-    TR_Failure(E_Extension(_), _) => { internal_error("unexpected cheri exception for cap store") },
     TR_Failure(e, _) => { handle_mem_exception(vaddrBits, e); RETIRE_FAIL },
     TR_Address(addr, _) => {
       let eares : MemoryOpResult(unit) = mem_write_ea_cap(addr, aq, rl, false);
@@ -1355,11 +1350,6 @@ function handle_store_cond_cap_via_cap(cs2, cs, cap_val, vaddrBits) = {
     RETIRE_SUCCESS
   } else {
     match translateAddr(vaddrBits, Write(if cs2_val.tag then Cap else Data)) {
-      TR_Failure(E_Extension(EXC_CHERI_VMEM_STORE_CAP), _) => {
-        handle_cheri_cap_exception(CapEx_TLBNoStoreCap, cs);
-        RETIRE_FAIL
-      },
-      TR_Failure(E_Extension(_), _) => { internal_error("unexpected cheri exception for cap store") },
       TR_Failure(e, _) => { handle_mem_exception(vaddrBits, e); RETIRE_FAIL },
       TR_Address(addr, _) => {
         let eares : MemoryOpResult(unit) = mem_write_ea_cap(addr, aq, rl, false);

--- a/src/cheri_pte.sail
+++ b/src/cheri_pte.sail
@@ -42,98 +42,62 @@ union PTE_Check = {
   PTE_Check_Failure : ext_ptw
 }
 
-function to_pte_check(b : bool) -> (bool, pte_check) =
-  (b, PTE_CAP_OK)
-
 function checkPTEPermission(ac : AccessType(ext_access_type), priv : Privilege, mxr : bool, do_sum : bool, p : PTE_Bits, ext : extPte, ext_ptw : ext_ptw) -> PTE_Check = {
-  let (succ, pte_chk) : (bool, pte_check) =
+  /*
+   * Although in many cases MXR doesn't make sense for capabilities, we honour
+   * it for three reasons:
+   *
+   * 1. It provides uniformity rather than giving strange and surprising edge cases.
+   *
+   * 2. The tag-dependence of stores is achieved by passing Data in for untagged
+   *    capabilities. Thus, not honouring MXR for capabilities would result in
+   *    differences in whether MXR had an effect based on the tag.
+   *
+   * 3. It's simpler to implement yet still safe (LC is unaffected by MXR).
+   */
+  let base_succ : bool =
   match (ac, priv) {
-    (Read(Data),      User)       => to_pte_check(p.U() == 0b1 & (p.R() == 0b1 | (p.X() == 0b1 & mxr))),
-    (Write(Data),     User)       => to_pte_check(p.U() == 0b1 & p.W() == 0b1),
-    (ReadWrite(Data), User)       => to_pte_check(p.U() == 0b1 & p.W() == 0b1 & (p.R() == 0b1 | (p.X() == 0b1 & mxr))),
-    (Execute(),       User)       => to_pte_check(p.U() == 0b1 & p.X() == 0b1),
+    (Read(_),      User)       => p.U() == 0b1 & (p.R() == 0b1 | (p.X() == 0b1 & mxr)),
+    (Write(_),     User)       => p.U() == 0b1 & p.W() == 0b1,
+    (ReadWrite(_), User)       => p.U() == 0b1 & p.W() == 0b1 & (p.R() == 0b1 | (p.X() == 0b1 & mxr)),
+    (Execute(),    User)       => p.U() == 0b1 & p.X() == 0b1,
 
-    (Read(Data),      Supervisor) => to_pte_check((p.U() == 0b0 | do_sum) & (p.R() == 0b1 | (p.X() == 0b1 & mxr))),
-    (Write(Data),     Supervisor) => to_pte_check((p.U() == 0b0 | do_sum) & p.W() == 0b1),
-    (ReadWrite(Data), Supervisor) => to_pte_check((p.U() == 0b0 | do_sum) & p.W() == 0b1 & (p.R() == 0b1 | (p.X() == 0b1 & mxr))),
-    (Execute(),       Supervisor) => to_pte_check(p.U() == 0b0 & p.X() == 0b1),
+    (Read(_),      Supervisor) => (p.U() == 0b0 | do_sum) & (p.R() == 0b1 | (p.X() == 0b1 & mxr)),
+    (Write(_),     Supervisor) => (p.U() == 0b0 | do_sum) & p.W() == 0b1,
+    (ReadWrite(_), Supervisor) => (p.U() == 0b0 | do_sum) & p.W() == 0b1 & (p.R() == 0b1 | (p.X() == 0b1 & mxr)),
+    (Execute(),    Supervisor) => p.U() == 0b0 & p.X() == 0b1,
 
-    (Read(Cap),       User)       => { /* load-cap should probably not be affected by mxr. */
-                                       if   p.U() == 0b1 & p.R() == 0b1
-                                       then {
-                                         let  e = Mk_Ext_PTE_Bits(ext);
-                                         if   e.LoadCap() == 0b1
-                                         then (true, PTE_CAP_OK)
-                                         else {
-                                           /* Allow the address translation to proceed, but mark for tag stripping */
-                                           (true, PTE_LOAD_CAP_ERR)
-                                         }
-                                       }
-                                       else (false, PTE_CAP_OK)
-                                     },
+    (_,            Machine)    => internal_error("m-mode mem perm check")
+  };
 
-    (Write(Cap),      User)       => { if   p.U() == 0b1 & p.W() == 0b1
-                                       then {
-                                         let  e = Mk_Ext_PTE_Bits(ext);
-                                         if   e.StoreCap() == 0b1
-                                         then (true, PTE_CAP_OK)
-                                         else {
-                                           /* Do not allow the address translation to proceed */
-                                           (false, PTE_STORE_CAP_ERR)
-                                         }
-                                       }
-                                       else (false, PTE_CAP_OK)
-                                     },
+  let e = Mk_Ext_PTE_Bits(ext);
+  let (succ, pte_chk) : (bool, pte_check) =
+  match (base_succ, ac) {
+    /* Base translation exceptions take priority over CHERI exceptions */
+    (false, _)               => (false, PTE_CAP_OK),
 
-    (ReadWrite(Cap),  User)       => { if   p.U() == 0b1 & p.R() == 0b1 & p.W() == 0b1
-                                       then {
-                                         let  e = Mk_Ext_PTE_Bits(ext);
-                                         if   e.StoreCap() == 0b1 & e.LoadCap() == 0b1
-                                         then (true, PTE_CAP_OK)
-                                         else if e.StoreCap() == 0b0
-                                         /* return a failure since we should cause an exception */
-                                         then (false, PTE_STORE_CAP_ERR)
-                                         /* return a success since the translation should proceed */
-                                         else (true, PTE_LOAD_CAP_ERR)
-                                       }
-                                       else (false, PTE_CAP_OK)
-                                     },
+    (true,  Read(Cap))       => if   e.LoadCap() == 0b1
+                                then (true, PTE_CAP_OK)
+                                /* Allow the address translation to proceed, but mark for tag stripping */
+                                else (true, PTE_LOAD_CAP_ERR),
 
-    (Read(Cap),       Supervisor) => { if   (p.U() == 0b0 | do_sum) & p.R() == 0b1
-                                       then {
-                                         let  e = Mk_Ext_PTE_Bits(ext);
-                                         if   e.LoadCap() == 0b1
-                                         then (true, PTE_CAP_OK)
-                                         else (true, PTE_LOAD_CAP_ERR)
-                                       }
-                                       else (false, PTE_CAP_OK)
-                                     },
+    (true,  Write(Cap))      => if   e.StoreCap() == 0b1
+                                then (true, PTE_CAP_OK)
+                                /* Do not allow the address translation to proceed */
+                                else (false, PTE_STORE_CAP_ERR),
 
-    (Write(Cap),      Supervisor) => { let e = Mk_Ext_PTE_Bits(ext);
-                                       if   (p.U() == 0b0 | do_sum) & p.W() == 0b1
-                                       then {
-                                         if   e.StoreCap() == 0b1
-                                         then (true,  PTE_CAP_OK)
-                                         else (false, PTE_STORE_CAP_ERR)
-                                       }
-                                       else (false, PTE_CAP_OK)
-                                     },
+    (true,  ReadWrite(Cap))  => if   e.StoreCap() == 0b1 & e.LoadCap() == 0b1
+                                then (true, PTE_CAP_OK)
+                                else if e.StoreCap() == 0b0
+                                /* Do not allow the address translation to proceed */
+                                then (false, PTE_STORE_CAP_ERR)
+                                /* Allow the address translation to proceed, but mark for tag stripping */
+                                else (true, PTE_LOAD_CAP_ERR),
 
-    (ReadWrite(Cap),  Supervisor) => { let e = Mk_Ext_PTE_Bits(ext);
-                                       if   (p.U() == 0b0 | do_sum) & p.R() == 0b1 & p.W() == 0b1
-                                       then {
-                                         if   e.StoreCap() == 0b1 & e.LoadCap() == 0b1
-                                         then (true, PTE_CAP_OK)
-                                         else if e.StoreCap() == 0b0
-                                         /* return a failure since we should cause an exception */
-                                         then (false, PTE_STORE_CAP_ERR)
-                                         /* return a success since the translation should proceed */
-                                         else (true, PTE_LOAD_CAP_ERR)
-                                       }
-                                       else (false, PTE_CAP_OK)
-                                     },
-
-    (_,               Machine)    => internal_error("m-mode mem perm check")
+    (true,  Read(Data))      => (true, PTE_CAP_OK),
+    (true,  Write(Data))     => (true, PTE_CAP_OK),
+    (true,  ReadWrite(Data)) => (true, PTE_CAP_OK),
+    (true,  Execute())       => (true, PTE_CAP_OK)
   };
 
   let ext_ptw = ext_accum_ptw_result(ext_ptw, pte_chk);

--- a/src/cheri_ptw.sail
+++ b/src/cheri_ptw.sail
@@ -27,8 +27,8 @@ overload to_str = {ptw_error_to_str}
 function ext_get_ptw_error(ext_ptw : ext_ptw) -> PTW_Error =
   match (ext_ptw) {
     PTW_CAP_OK        => PTW_No_Permission(),
-    PTW_LOAD_CAP_ERR  => PTW_Ext_Error(AT_LOAD_CAP_ERR),
-    PTW_STORE_CAP_ERR => PTW_Ext_Error(AT_STORE_CAP_ERR)
+    PTW_LOAD_CAP_ERR  => PTW_Ext_Error(AT_CAP_ERR),
+    PTW_STORE_CAP_ERR => PTW_Ext_Error(AT_CAP_ERR)
   }
 
 /* conversion of these translation/PTW failures into architectural exceptions */
@@ -36,9 +36,9 @@ function translationException(a : AccessType(ext_access_type), f : PTW_Error) ->
   let e : ExceptionType =
   match (a, f) {
     /* First handle the vmem extension errors */
-    (ReadWrite(Cap), PTW_Ext_Error(e)) => E_Extension(ext_translate_exception(e)),
-    (Read(Cap), PTW_Ext_Error(e))      => E_Extension(ext_translate_exception(e)),
-    (Write(Cap), PTW_Ext_Error(e))     => E_Extension(ext_translate_exception(e)),
+    (ReadWrite(Cap), PTW_Ext_Error(AT_CAP_ERR)) => E_Extension(EXC_SAMO_CAP_PAGE_FAULT),
+    (Read(Cap), PTW_Ext_Error(AT_CAP_ERR))      => E_Extension(EXC_LOAD_CAP_PAGE_FAULT),
+    (Write(Cap), PTW_Ext_Error(AT_CAP_ERR))     => E_Extension(EXC_SAMO_CAP_PAGE_FAULT),
 
     /* For other exceptions, Cap accesses fault similar to Data accesses below. */
     (ReadWrite(Cap), PTW_Access())  => E_SAMO_Access_Fault(),

--- a/src/cheri_ptw.sail
+++ b/src/cheri_ptw.sail
@@ -24,6 +24,13 @@ function ptw_error_to_str(e) =
 
 overload to_str = {ptw_error_to_str}
 
+function ext_get_ptw_error(ext_ptw : ext_ptw) -> PTW_Error =
+  match (ext_ptw) {
+    PTW_CAP_OK        => PTW_No_Permission(),
+    PTW_LOAD_CAP_ERR  => PTW_Ext_Error(AT_LOAD_CAP_ERR),
+    PTW_STORE_CAP_ERR => PTW_Ext_Error(AT_STORE_CAP_ERR)
+  }
+
 /* conversion of these translation/PTW failures into architectural exceptions */
 function translationException(a : AccessType(ext_access_type), f : PTW_Error) -> ExceptionType = {
   let e : ExceptionType =

--- a/src/cheri_riscv_types.sail
+++ b/src/cheri_riscv_types.sail
@@ -24,27 +24,39 @@ function ext_accum_ptw_result(ptw : ext_ptw, pte : pte_check) -> ext_ptw =
   }
 
 /* Address translation errors */
-enum ext_ptw_error = {AT_LOAD_CAP_ERR, AT_STORE_CAP_ERR}
+enum ext_ptw_error = {AT_CAP_ERR}
 
 /* CHERI exception extensions */
 
-enum ext_exc_type = {EXC_CHERI, EXC_CHERI_VMEM_LOAD_CAP, EXC_CHERI_VMEM_STORE_CAP}
-
-/* CHERI translation of PTW errors into exception annotations */
-function ext_translate_exception(e : ext_ptw_error) -> ext_exc_type =
-  match e {
-    AT_LOAD_CAP_ERR  => EXC_CHERI_VMEM_LOAD_CAP,
-    AT_STORE_CAP_ERR => EXC_CHERI_VMEM_STORE_CAP
+enum ext_exc_type = {
+  EXC_LOAD_CAP_PAGE_FAULT,
+  EXC_SAMO_CAP_PAGE_FAULT,
+  EXC_CHERI
 }
 
 /* CHERI conversion of extension exceptions to bits */
 val ext_exc_type_to_bits : ext_exc_type -> exc_code
-function ext_exc_type_to_bits(e) = 0x1C
+function ext_exc_type_to_bits(e) =
+  match (e) {
+    EXC_LOAD_CAP_PAGE_FAULT => 0x1a,
+    EXC_SAMO_CAP_PAGE_FAULT => 0x1b,
+    EXC_CHERI               => 0x1c
+  }
 
 /* CHERI conversion of extension exceptions to integers */
 val num_of_ext_exc_type : ext_exc_type -> {'n, (0 <= 'n < xlen). int('n)}
-function num_of_ext_exc_type(e) = 28
+function num_of_ext_exc_type(e) =
+  match (e) {
+    EXC_LOAD_CAP_PAGE_FAULT => 26,
+    EXC_SAMO_CAP_PAGE_FAULT => 27,
+    EXC_CHERI               => 28
+  }
 
 /* CHERI conversion of extension exceptions to strings */
 val ext_exc_type_to_str : ext_exc_type -> string
-function ext_exc_type_to_str(e) = "cheri-exception"
+function ext_exc_type_to_str(e) =
+  match (e) {
+    EXC_LOAD_CAP_PAGE_FAULT => "load-cap-page-fault",
+    EXC_SAMO_CAP_PAGE_FAULT => "store/amo-cap-page-fault",
+    EXC_CHERI               => "cheri"
+  }


### PR DESCRIPTION
Things were broken in several ways:

1. Our SC page fault was not tag-dependent

2. We never actually got custom exceptions, just vanilla page faults for missing LoadCap/StoreCap bits

3. We weren't using the recently-added top-level exception codes (what I initially came to fix, before going down the rabbit hole of 1 and 2)

This fixes all of that in a far cleaner way than the highly-duplicated code that was there before. Some of this likely overlaps with Wes's more featureful changes, but we need to get this merged to be able to TestRIG anything with the CHERI PTE bits and those are more invasive. This should then provide a better basis for them to work off.

This depends on https://github.com/rems-project/sail-riscv/pull/62 being merged (and when it is I will update this PR to use the corresponding merge commit for the submodule bump).

Passes my own hand-written tests (magic macros, support code to set up paging and run the tests, and trap handler that makes traps look like writebacks to s6/s7, not shown):

```asm
/*
 * Global register allocations
 * s0 - current test
 * s1 - vatopa
 * s2 - active PTE address
 * s3 - clean PTE value
 * s4 - scratch page
 * s6 - last mcause
 * s7 - last mtval
 */

BEGIN_TEST
	/* Test that we can store and load back a tagged value */
	cspecialr	ct0, ddc
	/* Sanity check */
	cgettag	t1, ct0
	ASSERT_EQ_I	t1, 1, t6
	/* Round trip through memory */
	sc	ct0, 0(s4)
	lc	ct0, 0(s4)
	/* Assert nothing trapped */
	ASSERT_EQ_I	s6, ~0, t6
	/* Assert the tag is still there */
	cgettag	t1, ct0
	ASSERT_EQ_I	t1, 1, t6
END_TEST

BEGIN_TEST
	/* Test that dropping PTE_SC traps for tagged values */
	/* Update the PTE */
	li	t0, ~(PTE_SC)
	and	t0, s3, t0
	sd	t0, 0(s2)
	sfence.vma
	cspecialr	ct0, ddc
	/* Sanity check */
	cgettag	t1, ct0
	ASSERT_EQ_I	t1, 1, t6
	/* Do the store */
	sc	ct0, 0(s4)
	/* Assert we trapped */
	ASSERT_EQ_I	s6, EXC_SAMO_CAP_FAULT, t6
	/* Assert we saw the right faulting address */
	ASSERT_EQ	s7, s4
END_TEST

BEGIN_TEST
	/* Test that dropping PTE_SC doesn't trap for untagged values */
	/* Update the PTE */
	li	t0, ~(PTE_SC)
	and	t0, s3, t0
	sd	t0, 0(s2)
	sfence.vma
	/* Do the store */
	sc	cnull, 0(s4)
	/* Assert nothing trapped */
	ASSERT_EQ_I	s6, ~0, t6
END_TEST

BEGIN_TEST
	/* Test that dropping PTE_LC tag strips on load */
	cspecialr	ct0, ddc
	/* Sanity check */
	cgettag	t1, ct0
	ASSERT_EQ_I	t1, 1, t6
	/* Store tagged value to location */
	sc	ct0, 0(s4)
	/* Sanity check */
	lc	ct0, 0(s4)
	cgettag	t1, ct0
	ASSERT_EQ_I	t1, 1, t6
	/* Update the PTE */
	li	t0, ~(PTE_LC)
	and	t0, s3, t0
	sd	t0, 0(s2)
	sfence.vma
	/* Do the load */
	lc	ct0, 0(s4)
	/* Assert nothing trapped */
	ASSERT_EQ_I	s6, ~0, t6
	/* Assert the tag was stripped */
	cgettag	t1, ct0
	ASSERT_EQ_I	t1, 0, t6
END_TEST
```