### PR TITLE
Legalise underivable caps

### DIFF
--- a/src/cheri_cap_common.sail
+++ b/src/cheri_cap_common.sail
@@ -245,7 +245,7 @@ function getCapLegalised(c) : Capability -> Capability =
     c
   else
     /* Legalise the capability by zeroing the ie bit, implicitly setting E to 0. TODO avoid 90 magic number */
-    capBitsToCapability(false, capToBits(c) & ~(to_bits(128, 1) << 90))
+    encCapabilityToCapability(false, {capToEncCap(c) with internal_e = bitzero})
 
 function getCapBoundsBits(c) : Capability -> (CapAddrBits, CapLenBits) =
   let c_legal = getCapLegalised(c) in

--- a/src/cheri_cap_common.sail
+++ b/src/cheri_cap_common.sail
@@ -32,10 +32,94 @@
 /*  SUCH DAMAGE.                                                          */
 /*========================================================================*/
 
-
+let MAX_ADDR = MAX(cap_addr_width)
+type CapAddrInt = range(0, (2 ^ cap_addr_width) - 1)
+type CapLen = range(0, (2 ^ cap_len_width) - 1)
 let max_otype = MAX(otype_width) - reserved_otypes
 type CapAddrBits = bits(cap_addr_width)
 type CapLenBits  = bits(cap_len_width)
+
+/* A partially decompressed version of a capability -- E, B, T,
+ * lenMSB, sealed and otype fields are not present in all formats and are
+ * populated by capBitsToCapability.
+ */
+struct Capability = {
+  tag                    : bool    ,
+  uperms                 : bits(uperms_width) ,
+  permit_set_CID         : bool    ,
+  access_system_regs     : bool    ,
+  permit_unseal          : bool    ,
+  permit_cinvoke         : bool    ,
+  permit_seal            : bool    ,
+  permit_store_local_cap : bool    ,
+  permit_store_cap       : bool    ,
+  permit_load_cap        : bool    ,
+  permit_store           : bool    ,
+  permit_load            : bool    ,
+  permit_execute         : bool    ,
+  global                 : bool    ,
+  reserved               : bits(reserved_width) ,
+  flag_cap_mode          : bool    ,
+  internal_e             : bool    ,
+  E                      : bits(exp_width),
+  sealed                 : bool    ,
+  B                      : bits(mantissa_width),
+  T                      : bits(mantissa_width),
+  otype                  : bits(otype_width),
+  address                : bits(cap_addr_width)
+}
+
+let null_cap : Capability = struct {
+  tag                    = false,
+  uperms                 = zeros(),
+  permit_set_CID         = false,
+  access_system_regs     = false,
+  permit_unseal          = false,
+  permit_cinvoke         = false,
+  permit_seal            = false,
+  permit_store_local_cap = false,
+  permit_store_cap       = false,
+  permit_load_cap        = false,
+  permit_store           = false,
+  permit_load            = false,
+  permit_execute         = false,
+  global                 = false,
+  reserved               = zeros(),
+  flag_cap_mode          = false,
+  internal_e             = true,
+  E                      = resetE,
+  sealed                 = false,
+  B                      = zeros(),
+  T                      = resetT,
+  otype                  = to_bits(otype_width, otype_unsealed),
+  address                = zeros()
+}
+
+let default_cap : Capability = struct {
+  tag                    = true,
+  uperms                 = ones(),
+  permit_set_CID         = true,
+  access_system_regs     = true,
+  permit_unseal          = true,
+  permit_cinvoke         = true,
+  permit_seal            = true,
+  permit_store_local_cap = true,
+  permit_store_cap       = true,
+  permit_load_cap        = true,
+  permit_store           = true,
+  permit_load            = true,
+  permit_execute         = true,
+  global                 = true,
+  reserved               = zeros(),
+  flag_cap_mode          = false,
+  internal_e             = true,
+  E                      = resetE,
+  sealed                 = false,
+  B                      = zeros(),
+  T                      = resetT,
+  otype                  = to_bits(otype_width, otype_unsealed),
+  address                = zeros()
+}
 
 function getCapHardPerms(cap) : Capability -> bits(12) =
    (bool_to_bits(cap.permit_set_CID)
@@ -51,29 +135,85 @@ function getCapHardPerms(cap) : Capability -> bits(12) =
   @ bool_to_bits(cap.permit_execute)
   @ bool_to_bits(cap.global))
 
-/* Convert from capabilty struct to bits (no tag) */
-function capToBits(cap) : Capability -> CapBits = {
-  t_hi : bits(mantissa_width - 5) = cap.T[mantissa_width - 3..3];
-  t_lo : bits(3)  = cap.T[2..0];
-  b_hi : bits(mantissa_width - 3) = cap.B[mantissa_width - 1..3];
-  b_lo : bits(3)  = cap.B[2..0];
-  if cap.internal_e then {
-    t_lo = cap.E[5..3];
-    b_lo = cap.E[2..0];
+/* Convert from capabilty bits (128 bits with tag) to a more convenient struct. */
+function encCapabilityToCapability(t,c) : (bool, EncCapability) -> Capability = {
+  let sealed : bool = c.otype != to_bits(otype_width, otype_unsealed);
+  internal_exponent : bool = bit_to_bool(c.internal_e);
+  E : bits(exp_width)  = zeros();
+  Bs : bits(mantissa_width) = zeros();
+  T : bits(mantissa_width - 2) = zeros();
+  lenMSBs : bits(2) = zeros();
+  if internal_exponent then {
+    E = c.T[internal_exponent_take_bits - 1..0] @ c.B[internal_exponent_take_bits - 1..0];
+    /* Exponent chosen so that length MSBs is 01 */
+    lenMSBs = 0b01;
+    T = c.T[mantissa_width - 3..3] @ zeros(internal_exponent_take_bits);
+    Bs = c.B[mantissa_width - 1..3] @ zeros(internal_exponent_take_bits);
+  } else {
+    /* Exponent zero */
+    lenMSBs = 0b00;
+    T = c.T;
+    Bs = c.B;
   };
-  return (cap.uperms
-    @ getCapHardPerms(cap)
-    @ cap.reserved
-    @ bool_to_bits(cap.flag_cap_mode)
-    @ cap.otype
-    @ bool_to_bits(cap.internal_e)
-    @ t_hi
-    @ t_lo
-    @ b_hi
-    @ b_lo
-    @ cap.address
-  );
+  /* Reconstruct top two bits of T given T = B + len and:
+   * 1) the top two bits of B
+   * 2) most significant two bits of length derived from format above
+   * 3) carry out of B[20..0] + len[20..0] that is implied if T[20..0] < B[20..0]
+   */
+  carry_out = if T <_u Bs[mantissa_width - 3..0] then 0b01 else 0b00;
+  Ttop2 = Bs[mantissa_width - 1..mantissa_width - 2] + lenMSBs + carry_out;
+  return struct {
+    tag                    = t,
+    uperms                 = if uperms_width > 0 then c.perms[12 + uperms_width - 1..12] else [],
+    permit_set_CID         = bit_to_bool(c.perms[11]),
+    access_system_regs     = bit_to_bool(c.perms[10]),
+    permit_unseal          = bit_to_bool(c.perms[9]),
+    permit_cinvoke         = bit_to_bool(c.perms[8]),
+    permit_seal            = bit_to_bool(c.perms[7]),
+    permit_store_local_cap = bit_to_bool(c.perms[6]),
+    permit_store_cap       = bit_to_bool(c.perms[5]),
+    permit_load_cap        = bit_to_bool(c.perms[4]),
+    permit_store           = bit_to_bool(c.perms[3]),
+    permit_load            = bit_to_bool(c.perms[2]),
+    permit_execute         = bit_to_bool(c.perms[1]),
+    global                 = bit_to_bool(c.perms[0]),
+    reserved               = c.reserved,
+    flag_cap_mode          = bit_to_bool(c.flags[0]),
+    internal_e             = internal_exponent,
+    E                      = E,
+    sealed                 = sealed,
+    B                      = Bs,
+    T                      = Ttop2 @ T,
+    otype                  = c.otype,
+    address                = c.address
+  }
 }
+
+function capBitsToCapability(t, c) : (bool, CapBits) -> Capability = encCapabilityToCapability(t, capBitsToEncCapability(c))
+
+function capToEncCap(cap) : Capability -> EncCapability = {
+  t_hi : bits(mantissa_width - 2 - internal_exponent_take_bits) = cap.T[mantissa_width - 3..internal_exponent_take_bits];
+  t_lo : bits(internal_exponent_take_bits)  = cap.T[internal_exponent_take_bits - 1..0];
+  b_hi : bits(mantissa_width - internal_exponent_take_bits) = cap.B[mantissa_width - 1..internal_exponent_take_bits];
+  b_lo : bits(internal_exponent_take_bits)  = cap.B[internal_exponent_take_bits - 1..0];
+  if cap.internal_e then {
+    t_lo = cap.E[2 * internal_exponent_take_bits - 1..internal_exponent_take_bits];
+    b_lo = cap.E[internal_exponent_take_bits - 1..0];
+  };
+  return struct {
+    perms = cap.uperms @ getCapHardPerms(cap),
+    reserved = cap.reserved,
+    flags = bool_to_bits(cap.flag_cap_mode),
+    otype = cap.otype,
+    internal_e = bool_to_bits(cap.internal_e)[0],
+    T = t_hi @ t_lo,
+    B = b_hi @ b_lo,
+    address = cap.address
+  };
+}
+
+/* Convert from capabilty struct to bits (no tag) */
+function capToBits(cap) : Capability -> CapBits = EncCapToBits(capToEncCap(cap))
 
 /* When saving/restoring capabilities xor them with bits of null_cap --
  * this ensures that canonical null_cap is always all-zeros in memory

--- a/src/cheri_cap_common.sail
+++ b/src/cheri_cap_common.sail
@@ -309,14 +309,15 @@ overload operator << = {sail_shiftleft}
 overload operator >>_s = {sail_arith_shiftright}
 
 function fastRepCheck(c, i) : (Capability, CapAddrBits) -> bool=
-    let E = unsigned(c.E) in
+    let c_legal = getCapLegalised(c) in
+    let E = unsigned(c_legal.E) in
     if (E >= maxE - 2) then
         true /* in this case representable region is whole address space */
     else
         let i_top    = signed(i >>_s (E + mantissa_width)) in
         let i_mid    = truncate(i >> E, mantissa_width)in
-        let a_mid    = truncate(c.address >> E, mantissa_width) in
-        let B3 = truncateLSB(c.B, 3) in
+        let a_mid    = truncate(c_legal.address >> E, mantissa_width) in
+        let B3 = truncateLSB(c_legal.B, 3) in
         let R3 = B3 - 0b001 in
         let R  = R3 @ zeros(mantissa_width - 3) in
         let diff  = R - a_mid in

--- a/src/cheri_cap_common.sail
+++ b/src/cheri_cap_common.sail
@@ -88,15 +88,34 @@ function capToMemBits(cap) : Capability -> CapBits =
 function memBitsToCapability(tag, b) : (bool, CapBits) -> Capability =
   capBitsToCapability(tag, b ^ null_cap_bits)
 
-
-
-function getCapBoundsBits(c) : Capability -> (CapAddrBits, CapLenBits) =
+function getCapBoundsBitsUncorrected(c) : Capability -> (CapLenBits, CapLenBits) =
   let E = min(maxE, unsigned(c.E)) in
   let a : CapAddrBits = c.address in
+  let a_ext : CapLenBits = EXTZ(a) in
+  let a_top = truncateLSB(a_ext, cap_len_width - E - mantissa_width) in
+  let base : CapLenBits = a_top @ c.B @ zeros(E) in
+  let top  : CapLenBits = a_top @ c.T @ zeros(E) in
+    (base, top)
+
+function getCapLegalised(c) : Capability -> Capability =
+  let (base, top) = getCapBoundsBitsUncorrected(c) in
+  /* Check that base is within the address space */
+  if unsigned(c.E) <= maxE
+   & (base <_u (to_bits(cap_len_width, 1) << cap_addr_width)) then
+    c
+  else
+    /* Legalise the capability by zeroing the ie bit, implicitly setting E to 0. TODO avoid 90 magic number */
+    capBitsToCapability(false, capToBits(c) & ~(to_bits(128, 1) << 90))
+
+function getCapBoundsBits(c) : Capability -> (CapAddrBits, CapLenBits) =
+  let c_legal = getCapLegalised(c) in
+  let E = unsigned(c_legal.E) in
+  let a : CapAddrBits = c_legal.address in
+  let (base, top) = getCapBoundsBitsUncorrected(c_legal) in
   /* Extract bits we need to make the top correction and calculate representable limit */
   let a3 = truncate(a >> (E + mantissa_width - 3), 3) in
-  let B3 = truncateLSB(c.B, 3) in
-  let T3 = truncateLSB(c.T, 3) in
+  let B3 = truncateLSB(c_legal.B, 3) in
+  let T3 = truncateLSB(c_legal.T, 3) in
   let R3 = B3 - 0b001 in /* wraps */
   /* Do address, base and top lie in the R aligned region above the one containing R? */
   let aHi = if a3 <_u R3 then 1 else 0 in
@@ -104,25 +123,13 @@ function getCapBoundsBits(c) : Capability -> (CapAddrBits, CapLenBits) =
   let tHi = if T3 <_u R3 then 1 else 0 in
   /* Compute region corrections for top and base relative to a */
   let correction_base = bHi - aHi in
-  let correction_top  = tHi - aHi in
-  let a_top = (a >> (E + mantissa_width)) in {
-    base : CapLenBits = truncate((a_top + correction_base) @ c.B @ zeros(E), cap_len_width);
-    top  : CapLenBits = truncate((a_top + correction_top)  @ c.T @ zeros(E), cap_len_width);
-    /* If the base and top are more than an address space away from each other,
-       invert the MSB of top.  This corrects for errors that happen when the
-       representable space wraps the address space. */
-    let base2 : bits(2) = 0b0 @ [base[cap_addr_width - 1]];
-    let top2  : bits(2) = top[cap_addr_width .. cap_addr_width - 1];
-    if (E < (maxE - 1)) & (unsigned(top2 - base2) > 1) then {
-      top[cap_addr_width] = ~(top[cap_addr_width]);
-    };
-    /* TODO The following top MSB correction was thought to be equivalent
-       to the one above, but differs at least in some cases where E >= maxE - 1
-    if (base[cap_addr_width] == bitone) then {
-       top[cap_addr_width] = if (aHi == 1) & (tHi == 1) then bitone else bitzero;
-    };
-    */
-    (base[(cap_addr_width - 1)..0], top)
+  let correction_top  = tHi - aHi in {
+    base_corrected : CapLenBits = base + (to_bits(cap_len_width, correction_base) << (mantissa_width + E));
+    top_corrected : CapLenBits = top + (to_bits(cap_len_width, correction_top) << (mantissa_width + E));
+    /* Interpret the top relative to the address space of the base.
+       This corrects for errors that happen when the representable space wraps the address space. */
+    top_corrected[cap_len_width - 1 .. cap_addr_width] = top_corrected[cap_len_width - 1 .. cap_addr_width] - base_corrected[cap_len_width - 1 .. cap_addr_width];
+    (truncate(base_corrected, cap_addr_width), top_corrected)
   }
 
 function getCapBounds(cap) : Capability -> (CapAddrInt, CapLen) =
@@ -132,7 +139,7 @@ function getCapBounds(cap) : Capability -> (CapAddrInt, CapLen) =
 /* An 'ideal' version of setCapBounds as described in paper. */
 function setCapBounds(cap, base, top) : (Capability, CapAddrBits, CapLenBits) -> (bool, Capability) = {
   /* {cap with base=base; length=(bits(64)) length; offset=0} */
-  let ext_base = 0b0 @ base;
+  let ext_base : CapLenBits = EXTZ(base);
   let length = top - ext_base;
   /* Find an exponent that will put the most significant bit of length
    * second from the top as assumed during decoding. We ignore the bottom
@@ -263,13 +270,8 @@ function getCapOffset(c) : Capability -> CapAddrInt =
 
 function getCapLength(c) : Capability -> CapLen =
     let ('base, 'top) = getCapBounds(c) in {
-        /* For valid capabilties we expect top >= base and hence
-         * length >= 0 but representation does allow top < base in some
-         * cases so might encounter on untagged capabilities. Here we just
-         * pretend it is a 65-bit quantitiy and wrap.
-         */
-        assert (not(c.tag) | top >= base);
-        (top - base) % pow2(cap_len_width)
+        assert(top >= base);
+        top - base
     }
 
 val inCapBounds  : (Capability, CapAddrBits, CapLen) -> bool
@@ -372,7 +374,7 @@ function capToString (cap) = {
   concat_str(" length:", len_str)))))))))))))
 }
 function getRepresentableAlignmentMask(len) : xlenbits -> xlenbits = {
-  let (exact, c) = setCapBounds(default_cap, to_bits(sizeof(xlen), 0), 0b0 @ len);
+  let (exact, c) = setCapBounds(default_cap, to_bits(sizeof(xlen), 0), EXTZ(len));
   let e = min(unsigned(c.E), maxE);
   let e' = if c.internal_e then e + internal_exponent_take_bits else 0;
   ones(sizeof(xlen)-e') @ zeros(e')

--- a/src/cheri_insts.sail
+++ b/src/cheri_insts.sail
@@ -491,7 +491,7 @@ function clause execute (CBuildCap(cd, cs1, cs2)) =
     RETIRE_FAIL
   } else {
     let (exact, cd1) = setCapBounds(cs1_val, to_bits(cap_addr_width, cs2_base), to_bits(cap_len_width, cs2_top));
-    let (representable, cd2) = setCapOffset(cd1, getCapOffsetBits(cs2_val));
+    let (_, cd2) = setCapOffset(cd1, getCapOffsetBits(cs2_val)); // Ignore representability check, since Fast Rep Check not relevant
     let cd3 = setCapPerms(cd2, cs2_perms);
     let cd4 = setCapFlags(cd3, cs2_flags);
     let cd5 = if cs2_val.otype == to_bits(otype_width, otype_sentry) then sealCap(cd4, to_bits(otype_width, otype_sentry)) else cd4;

--- a/src/cheri_insts.sail
+++ b/src/cheri_insts.sail
@@ -494,9 +494,13 @@ function clause execute (CBuildCap(cd, cs1, cs2)) =
     let (_, cd2) = setCapOffset(cd1, getCapOffsetBits(cs2_val)); // Ignore representability check, since Fast Rep Check not relevant
     let cd3 = setCapPerms(cd2, cs2_perms);
     let cd4 = setCapFlags(cd3, cs2_flags);
-    let cd5 = if cs2_val.otype == to_bits(otype_width, otype_sentry) then sealCap(cd4, to_bits(otype_width, otype_sentry)) else cd4;
+    if cd4 != {unsealCap(cs2_val) with tag=true} then
     {
+      handle_cheri_reg_exception(CapEx_LengthViolation, cs2);
+      RETIRE_FAIL
+    } else {
       assert(exact, "CBuildCap: setCapBounds was not exact"); /* base and top came from cs2 originally so will be exact */
+      let cd5 = if cs2_val.otype == to_bits(otype_width, otype_sentry) then sealCap(cd4, to_bits(otype_width, otype_sentry)) else cd4;
       writeCapReg(cd, cd5);
       RETIRE_SUCCESS
     }

--- a/src/cheri_prelude_128.sail
+++ b/src/cheri_prelude_128.sail
@@ -45,14 +45,16 @@ type uperms_width : Int = 4
 let uperms_width = sizeof(uperms_width)
 type cap_addr_width : Int = xlen
 let  cap_addr_width = sizeof(cap_addr_width)
-type cap_len_width : Int = cap_addr_width + 1
-let  cap_len_width  = sizeof(cap_len_width)
 type mantissa_width : Int = 14
 let  mantissa_width = sizeof(mantissa_width)
+type exp_width : Int = 6
+let  exp_width = sizeof(exp_width)
+type cap_len_width : Int = cap_addr_width + 2
+let  cap_len_width  = sizeof(cap_len_width)
 
 let MAX_ADDR = MAX(cap_addr_width)
-type CapAddrInt = range(0, (2 ^ 64) - 1) /* XXX should be cap_addr_width */
-type CapLen = range(0, 2 ^ 65) /* XXX sail can't handle if this is expressed as cap_len_width */
+type CapAddrInt = range(0, (2 ^ cap_addr_width) - 1)
+type CapLen = range(0, (2 ^ cap_len_width) - 1)
 
 /* A partially decompressed version of a capability -- E, B, T,
  * lenMSB, sealed and otype fields are not present in all formats and are
@@ -76,7 +78,7 @@ struct Capability = {
   reserved               : bits(2) ,
   flag_cap_mode          : bool    ,
   internal_e             : bool    ,
-  E                      : bits(6) ,
+  E                      : bits(exp_width),
   sealed                 : bool    ,
   B                      : bits(mantissa_width),
   T                      : bits(mantissa_width),
@@ -87,7 +89,7 @@ struct Capability = {
 /* Reset E and T calculated to make top 2**64. */
 let maxE = 52
 let internal_exponent_take_bits = 3
-let resetE = to_bits(6, maxE)
+let resetE = to_bits(exp_width, maxE)
 let resetT = 0b01 @ 0x000 /* bit 12 set */
 
 let null_cap : Capability = struct {

--- a/src/cheri_prelude_128.sail
+++ b/src/cheri_prelude_128.sail
@@ -34,15 +34,15 @@
 
 /* width of capability in bytes (excluding tag) */
 type cap_size : Int = 16
-let cap_size = sizeof(cap_size)
+let  cap_size = sizeof(cap_size)
 type log2_cap_size : Int = 4
-let log2_cap_size = sizeof(log2_cap_size)
+let  log2_cap_size = sizeof(log2_cap_size)
 type CapBits = bits(8 * cap_size)
 /* width of otype field in bits */
 type otype_width : Int = 18
-let otype_width = sizeof(otype_width)
+let  otype_width = sizeof(otype_width)
 type uperms_width : Int = 4
-let uperms_width = sizeof(uperms_width)
+let  uperms_width = sizeof(uperms_width)
 type cap_addr_width : Int = xlen
 let  cap_addr_width = sizeof(cap_addr_width)
 type mantissa_width : Int = 14
@@ -51,151 +51,45 @@ type exp_width : Int = 6
 let  exp_width = sizeof(exp_width)
 type cap_len_width : Int = cap_addr_width + 2
 let  cap_len_width  = sizeof(cap_len_width)
-
-let MAX_ADDR = MAX(cap_addr_width)
-type CapAddrInt = range(0, (2 ^ cap_addr_width) - 1)
-type CapLen = range(0, (2 ^ cap_len_width) - 1)
-
-/* A partially decompressed version of a capability -- E, B, T,
- * lenMSB, sealed and otype fields are not present in all formats and are
- * populated by capBitsToCapability.
- */
-struct Capability = {
-  tag                    : bool    ,
-  uperms                 : bits(uperms_width) ,
-  permit_set_CID         : bool    ,
-  access_system_regs     : bool    ,
-  permit_unseal          : bool    ,
-  permit_cinvoke         : bool    ,
-  permit_seal            : bool    ,
-  permit_store_local_cap : bool    ,
-  permit_store_cap       : bool    ,
-  permit_load_cap        : bool    ,
-  permit_store           : bool    ,
-  permit_load            : bool    ,
-  permit_execute         : bool    ,
-  global                 : bool    ,
-  reserved               : bits(2) ,
-  flag_cap_mode          : bool    ,
-  internal_e             : bool    ,
-  E                      : bits(exp_width),
-  sealed                 : bool    ,
-  B                      : bits(mantissa_width),
-  T                      : bits(mantissa_width),
-  otype                  : bits(otype_width),
-  address                : bits(cap_addr_width)
-}
+type reserved_width : Int = 2
+let  reserved_width = sizeof(reserved_width)
 
 /* Reset E and T calculated to make top 2**64. */
-let maxE = 52
-let internal_exponent_take_bits = 3
-let resetE = to_bits(exp_width, maxE)
-let resetT = 0b01 @ 0x000 /* bit 12 set */
+let  maxE = 52
+type internal_exponent_take_bits : Int = 3
+let  internal_exponent_take_bits = sizeof(internal_exponent_take_bits)
+let  resetE = to_bits(exp_width, maxE)
+let  resetT = 0b01 @ 0x000 /* bit 12 set */
 
-let null_cap : Capability = struct {
-  tag                    = false,
-  uperms                 = zeros(),
-  permit_set_CID         = false,
-  access_system_regs     = false,
-  permit_unseal          = false,
-  permit_cinvoke         = false,
-  permit_seal            = false,
-  permit_store_local_cap = false,
-  permit_store_cap       = false,
-  permit_load_cap        = false,
-  permit_store           = false,
-  permit_load            = false,
-  permit_execute         = false,
-  global                 = false,
-  reserved               = zeros(),
-  flag_cap_mode          = false,
-  internal_e             = true,
-  E                      = resetE,
-  sealed                 = false,
-  B                      = zeros(),
-  T                      = resetT,
-  otype                  = to_bits(otype_width, otype_unsealed),
-  address                = zeros()
+/* Capability format completely compressed. Tag is out of band */
+struct EncCapability = {
+  perms      : bits(uperms_width + 12) ,
+  otype      : bits(otype_width) ,
+  reserved   : bits(reserved_width) ,
+  flags      : bits(1) ,
+  internal_e : bit ,
+  T          : bits(mantissa_width - 2) ,
+  B          : bits(mantissa_width) ,
+  address    : bits(cap_addr_width)
 }
 
-let default_cap : Capability = struct {
-  tag                    = true,
-  uperms                 = ones(),
-  permit_set_CID         = true,
-  access_system_regs     = true,
-  permit_unseal          = true,
-  permit_cinvoke         = true,
-  permit_seal            = true,
-  permit_store_local_cap = true,
-  permit_store_cap       = true,
-  permit_load_cap        = true,
-  permit_store           = true,
-  permit_load            = true,
-  permit_execute         = true,
-  global                 = true,
-  reserved               = zeros(),
-  flag_cap_mode          = false,
-  internal_e             = true,
-  E                      = resetE,
-  sealed                 = false,
-  B                      = zeros(),
-  T                      = resetT,
-  otype                  = to_bits(otype_width, otype_unsealed),
-  address                = zeros()
+function capBitsToEncCapability(c) : CapBits -> EncCapability = struct {
+  perms      = c[127..112],
+  reserved   = c[111..110],
+  flags      = c[109..109],
+  otype      = c[108..91],
+  internal_e = c[90],
+  T          = c[89..78],
+  B          = c[77..64],
+  address    = c[63..0]
 }
 
-/* Convert from capabilty bits (128 bits with tag) to a more convenient struct. */
-function capBitsToCapability(t, c) : (bool, CapBits) -> Capability = {
-  internal_exponent : bool = bit_to_bool(c[90]);
-  otype : bits(18) = c[108..91];
-  let sealed : bool = otype != to_bits(otype_width, otype_unsealed);
-  E : bits(6)  = zeros();
-  Bs : bits(14) = zeros();
-  T : bits(12) = zeros();
-  lenMSBs : bits(2) = zeros();
-  if internal_exponent then {
-    /* Exponent stored instead of T[2..0] and B[2..0] */
-    E = c[80..78] @ c [66..64];
-    /* Exponent chosen so that length MSBs is 01 */
-    lenMSBs = 0b01;
-    T = c[89..81] @ 0b000;
-    Bs = c[77..67] @ 0b000;
-  } else {
-    /* Exponent zero */
-    lenMSBs = 0b00;
-    T = c[89..78];
-    Bs = c[77..64];
-  };
-  /* Reconstruct top two bits of T given T = B + len and:
-   * 1) the top two bits of B
-   * 2) most significant two bits of length derived from format above
-   * 3) carry out of B[20..0] + len[20..0] that is implied if T[20..0] < B[20..0]
-   */
-  carry_out = if T <_u Bs[11..0] then 0b01 else 0b00;
-  Ttop2 = Bs[13..12] + lenMSBs + carry_out;
-  return struct {
-    tag                    = t,
-    uperms                 = c[127..124],
-    permit_set_CID         = bit_to_bool(c[123]),
-    access_system_regs     = bit_to_bool(c[122]),
-    permit_unseal          = bit_to_bool(c[121]),
-    permit_cinvoke         = bit_to_bool(c[120]),
-    permit_seal            = bit_to_bool(c[119]),
-    permit_store_local_cap = bit_to_bool(c[118]),
-    permit_store_cap       = bit_to_bool(c[117]),
-    permit_load_cap        = bit_to_bool(c[116]),
-    permit_store           = bit_to_bool(c[115]),
-    permit_load            = bit_to_bool(c[114]),
-    permit_execute         = bit_to_bool(c[113]),
-    global                 = bit_to_bool(c[112]),
-    reserved               = c[111..110],
-    flag_cap_mode          = bit_to_bool(c[109]),
-    internal_e             = internal_exponent,
-    E                      = E,
-    sealed                 = sealed,
-    B                      = Bs,
-    T                      = Ttop2 @ T,
-    otype                  = otype,
-    address                = c[63..0]
-  }
-}
+function EncCapToBits(cap) : EncCapability -> CapBits =
+  cap.perms @
+  cap.reserved @
+  cap.flags @
+  cap.otype @
+  [cap.internal_e] @
+  cap.T @
+  cap.B @
+  cap.address

--- a/src/cheri_prelude_64.sail
+++ b/src/cheri_prelude_64.sail
@@ -45,182 +45,51 @@ type uperms_width : Int = 0
 let uperms_width = sizeof(uperms_width)
 type cap_addr_width : Int = xlen
 let  cap_addr_width = sizeof(cap_addr_width)
-type cap_len_width : Int = xlen + 1
-let  cap_len_width  = sizeof(cap_len_width)
 type mantissa_width : Int = 8
 let mantissa_width = sizeof(mantissa_width)
-
-let MAX_ADDR = MAX(cap_addr_width)
-type CapAddrInt = range(0, (2 ^ cap_addr_width) - 1)
-type CapLen = range(0, 2 ^ 33) /* XXX sail can't handle if this is expressed as cap_len_width */
-
-/* A partially decompressed version of a capability -- E, B, T,
- * lenMSB, sealed and otype fields are not present in all formats and are
- * populated by capBitsToCapability.
- */
-struct Capability = {
-  tag                    : bool    ,
-  uperms                 : bits(uperms_width) ,
-  permit_set_CID         : bool    ,
-  access_system_regs     : bool    ,
-  permit_unseal          : bool    ,
-  permit_cinvoke         : bool    ,
-  permit_seal            : bool    ,
-  permit_store_local_cap : bool    ,
-  permit_store_cap       : bool    ,
-  permit_load_cap        : bool    ,
-  permit_store           : bool    ,
-  permit_load            : bool    ,
-  permit_execute         : bool    ,
-  global                 : bool    ,
-  reserved               : bits(0) ,
-  flag_cap_mode          : bool    ,
-  internal_e             : bool    ,
-  E                      : bits(6) ,
-  sealed                 : bool    ,
-  B                      : bits(mantissa_width),
-  T                      : bits(mantissa_width),
-  otype                  : bits(otype_width),
-  address                : bits(cap_addr_width),
-}
+type exp_width : Int = 6
+let exp_width = sizeof(exp_width)
+type cap_len_width : Int = cap_addr_width + 2
+let  cap_len_width  = sizeof(cap_len_width)
+type reserved_width : Int = 0
+let  reserved_width = sizeof(reserved_width)
 
 /* Reset E and T calculated to make top 2**32. */
-let maxE = 26
-let internal_exponent_take_bits = 3
-let resetE = to_bits(6, maxE)
-let resetT = 0b01000000 /* bit 6 set */
+let  maxE = 26
+type internal_exponent_take_bits : Int = 3
+let  internal_exponent_take_bits = sizeof(internal_exponent_take_bits)
+let  resetE = to_bits(exp_width, maxE)
+let  resetT = 0b01000000 /* bit 6 set */
 
-let null_cap : Capability = struct {
-  tag                    = false,
-  uperms                 = zeros(),
-  permit_set_CID         = false,
-  access_system_regs     = false,
-  permit_unseal          = false,
-  permit_cinvoke         = false,
-  permit_seal            = false,
-  permit_store_local_cap = false,
-  permit_store_cap       = false,
-  permit_load_cap        = false,
-  permit_store           = false,
-  permit_load            = false,
-  permit_execute         = false,
-  global                 = false,
-  reserved               = zeros(),
-  flag_cap_mode          = false,
-  internal_e             = true,
-  E                      = resetE,
-  sealed                 = false,
-  B                      = zeros(),
-  T                      = resetT,
-  otype                  = to_bits(otype_width, otype_unsealed),
-  address                = zeros()
+/* Capability format completely compressed. Tag is out of band */
+struct EncCapability = {
+  perms      : bits(uperms_width + 12) ,
+  otype      : bits(otype_width) ,
+  reserved   : bits(reserved_width) ,
+  flags      : bits(1) ,
+  internal_e : bit ,
+  T          : bits(mantissa_width - 2) ,
+  B          : bits(mantissa_width) ,
+  address    : bits(cap_addr_width)
 }
 
-let default_cap : Capability = struct {
-  tag                    = true,
-  uperms                 = ones(),
-  permit_set_CID         = true,
-  access_system_regs     = true,
-  permit_unseal          = true,
-  permit_cinvoke         = true,
-  permit_seal            = true,
-  permit_store_local_cap = true,
-  permit_store_cap       = true,
-  permit_load_cap        = true,
-  permit_store           = true,
-  permit_load            = true,
-  permit_execute         = true,
-  global                 = true,
-  reserved               = zeros(),
-  flag_cap_mode          = false,
-  internal_e             = true,
-  E                      = resetE,
-  sealed                 = false,
-  B                      = zeros(),
-  T                      = resetT,
-  otype                  = to_bits(otype_width, otype_unsealed),
-  address                = zeros()
+function capBitsToEncCapability(c) : CapBits -> EncCapability = struct {
+  perms      = c[63..52],
+  reserved   = [],
+  flags      = c[51..51],
+  otype      = c[50..47],
+  internal_e = c[46],
+  T          = c[45..40],
+  B          = c[39..32],
+  address    = c[31..0]
 }
 
-/* Convert from capabilty bits (128 bits with tag) to a more convenient struct. */
-function capBitsToCapability(t, c) : (bool, CapBits) -> Capability = {
-  internal_exponent : bool = bit_to_bool(c[46]);
-  otype : bits(4) = c[50..47];
-  let sealed : bool = otype != to_bits(otype_width, otype_unsealed);
-  E : bits(6)  = zeros();
-  Bs : bits(8) = zeros();
-  T : bits(6) = zeros();
-  lenMSBs : bits(2) = zeros();
-  if internal_exponent then {
-    /* Exponent stored instead of T[2..0] and B[2..0] */
-    E = c[42..40] @ c [34..32];
-    /* Exponent chosen so that length MSBs is 01 */
-    lenMSBs = 0b01;
-    T = c[45..43] @ 0b000;
-    Bs = c[39..35] @ 0b000;
-  } else {
-    /* Exponent zero */
-    lenMSBs = 0b00;
-    T = c[45..40];
-    Bs = c[39..32];
-  };
-  /* Reconstruct top two bits of T given T = B + len and:
-   * 1) the top two bits of B
-   * 2) most significant two bits of length derived from format above
-   * 3) carry out of B[20..0] + len[20..0] that is implied if T[20..0] < B[20..0]
-   */
-  carry_out = if T <_u Bs[5..0] then 0b01 else 0b00;
-  Ttop2 = Bs[7..6] + lenMSBs + carry_out;
-  return struct {
-    tag                    = t,
-    uperms                 = [],
-    permit_set_CID         = bit_to_bool(c[63]),
-    access_system_regs     = bit_to_bool(c[62]),
-    permit_unseal          = bit_to_bool(c[61]),
-    permit_cinvoke         = bit_to_bool(c[60]),
-    permit_seal            = bit_to_bool(c[59]),
-    permit_store_local_cap = bit_to_bool(c[58]),
-    permit_store_cap       = bit_to_bool(c[57]),
-    permit_load_cap        = bit_to_bool(c[56]),
-    permit_store           = bit_to_bool(c[55]),
-    permit_load            = bit_to_bool(c[54]),
-    permit_execute         = bit_to_bool(c[53]),
-    global                 = bit_to_bool(c[52]),
-    reserved               = [],
-    flag_cap_mode          = bit_to_bool(c[51]),
-    internal_e             = internal_exponent,
-    E                      = E,
-    sealed                 = sealed,
-    B                      = Bs,
-    T                      = Ttop2 @ T,
-    otype                  = otype,
-    address                = c[31..0]
-  }
-}
-
-/*
-function fastRepCheck(c, i) : (Capability, bits(64)) -> bool=
-    let 'E = unsigned(c.E) in
-    if (E >= maxE) then
-        true /* in this case representable region is whole address space */
-    else
-        let E'       = min(E, maxE) in
-        let i_top    = signed(i >>_s (E+23)) in
-        let i_mid : bits(23) = truncate(i >>_s E)in
-        let a_mid : bits(23) = truncate(c.address >> E) in
-        let R : bits(20)     = (c.B) - 0x01000 in
-        let diff : bits(20)  = R - a_mid in
-        let diff1 : bits(20) = diff - 1 in
-        /* i_top determines 1. whether the increment is inRange
-           i.e. less than the size of the representable region
-           (2**(E+20)) and 2. whether it is positive or negative. To
-           satisfy 1. all top bits must be the same so we are
-           interested in the cases i_top is 0 or -1 */
-        if (i_top == 0) then
-          i_mid <_u diff1
-        else if (i_top == -1) then
-          (i_mid >=_u diff) & (R != a_mid)
-        else
-          false
-*/
-
+function EncCapToBits(cap) : EncCapability -> CapBits =
+  cap.perms @
+  cap.reserved @
+  cap.flags @
+  cap.otype @
+  [cap.internal_e] @
+  cap.T @
+  cap.B @
+  cap.address


### PR DESCRIPTION
Tested to match the Bluespec cheri-cap-lib implementation (PR pending).

Also includes refactoring to allow an intermediate struct without any decoding. This is required to neatly clear the IE bit, but has the side-effect of reducing duplicated code in preludes.