### PR TITLE
Also initialize {s,u}ccsr.{d,e}

### DIFF
--- a/src/cheri_regs.sail
+++ b/src/cheri_regs.sail
@@ -147,6 +147,10 @@ function ext_init_regs () = {
   misa->X() = 0b1;
   mccsr->d() = 0b1;
   mccsr->e() = 0b1;
+  sccsr->d() = 0b1;
+  sccsr->e() = 0b1;
+  uccsr->d() = 0b1;
+  uccsr->e() = 0b1;
 }
 
 /*!


### PR DESCRIPTION
This was being done in cheri_step_ext.sail, but not here.