### PR TITLE
Stop reporting cap_cause and cap_index in xCCSR

### DIFF
--- a/src/cheri_addr_checks.sail
+++ b/src/cheri_addr_checks.sail
@@ -4,14 +4,10 @@ val handle_cheri_cap_exception : (CapEx, capreg_idx) -> unit effect {escape, rre
 function handle_cheri_cap_exception(capEx, regnum) =
   {
     print("CHERI " ^ string_of_capex(capEx) ^ " Reg=" ^ BitStr(regnum));
-    let cause : cheri_cause = struct {
-        cap_idx = regnum,
-        capEx   = capEx
-    };
     let t : sync_exception = struct {
       trap    = E_Extension(EXC_CHERI),
       excinfo = Some(EXTZ(regnum @ CapExCode(capEx)) : xlenbits),
-      ext     = Some(cause)
+      ext     = None()
     };
     set_next_pc(exception_handler(cur_privilege, CTL_TRAP(t), PC))
   }

--- a/src/cheri_addr_checks.sail
+++ b/src/cheri_addr_checks.sail
@@ -18,7 +18,7 @@ function handle_cheri_cap_exception(capEx, regnum) =
 
 /*!
  * Causes the processor to raise a capability exception by writing the given
- * capability exception cause and register number to the xccsr register then
+ * capability exception cause and register number to the xtval register then
  * signalling an exception.
  */
 val handle_cheri_reg_exception : (CapEx, regidx) -> unit effect {escape, rreg, wreg}

--- a/src/cheri_sys_exceptions.sail
+++ b/src/cheri_sys_exceptions.sail
@@ -9,31 +9,16 @@ type ext_exception = cheri_cause
 function handle_trap_extension(p : Privilege, pc : xlenbits, ccause : option(cheri_cause)) -> unit = {
   match p {
     Machine => {
-      match ccause {
-        Some(c) => { mccsr->cap_idx() = c.cap_idx;
-                     mccsr->cause()   = CapExCode(c.capEx) },
-        _       => ()
-      };
       let (representable, mepcc) = setCapAddr(PCC, pc);
       assert(representable, "mepcc should always be representable");
       MEPCC   = mepcc
     },
     Supervisor => {
-      match ccause {
-        Some(c) => { sccsr->cap_idx() = c.cap_idx;
-                     sccsr->cause()   = CapExCode(c.capEx) },
-        _       => ()
-      };
       let (representable, sepcc) = setCapAddr(PCC, pc);
       assert(representable, "sepcc should always be representable");
       SEPCC   = sepcc
     },
     User => {
-      match ccause {
-        Some(c) => { uccsr->cap_idx() = c.cap_idx;
-                     uccsr->cause()   = CapExCode(c.capEx) },
-        _       => ()
-      };
       let (representable, uepcc) = setCapAddr(PCC, pc);
       assert(representable, "uepcc should always be representable");
       UEPCC   = uepcc

--- a/src/cheri_sys_exceptions.sail
+++ b/src/cheri_sys_exceptions.sail
@@ -1,12 +1,12 @@
 /* CHERI exception model */
 
-type ext_exception = cheri_cause
+type ext_exception = unit
 
 /*
  * On traps, EPCC comes to hold PCC verbatim.  Notably, PCC is not sealed under
  * otype_sentry (contrast, for example, CJALR).
  */
-function handle_trap_extension(p : Privilege, pc : xlenbits, ccause : option(cheri_cause)) -> unit = {
+function handle_trap_extension(p : Privilege, pc : xlenbits, u : option(unit)) -> unit = {
   match p {
     Machine => {
       let (representable, mepcc) = setCapAddr(PCC, pc);

--- a/src/cheri_sys_regs.sail
+++ b/src/cheri_sys_regs.sail
@@ -3,8 +3,6 @@
 /* Capability control csr */
 
 bitfield ccsr : xlenbits = {
-  cap_idx : 15 .. 10,
-  cause   :  9 .. 5, /* cap cause */
   d       :  1,      /* dirty  */
   e       :  0       /* enable */
 }
@@ -21,8 +19,6 @@ function legalize_ccsr(c : ccsr, v : xlenbits) -> ccsr = {
   // Technically, WPRI does not need a legalizer, since software is
   // assumed to legalize; so we could remove this function.
   let v = Mk_ccsr(v);
-  let c = update_cap_idx(c, v.cap_idx());
-  let c = update_cause(c, v.cause());
   /* For now these bits are not really supported so hardwired to true */
   let c = update_d(c, 0b1);
   let c = update_e(c, 0b1);

--- a/src/cheri_types.sail
+++ b/src/cheri_types.sail
@@ -139,9 +139,4 @@ type capreg_idx = bits(6)
 let PCC_IDX : capreg_idx = 0b100000
 let DDC_IDX : capreg_idx = 0b100001
 
-struct cheri_cause = {
-  cap_idx : capreg_idx,
-  capEx   : CapEx
-}
-
 type screg = bits(5)


### PR DESCRIPTION
These values are reported in xtval, so this information is redundant.