### PR TITLE
Add cap-mode dependent lr / sc and AMOSWAP

### DIFF
--- a/src/cheri_insts.sail
+++ b/src/cheri_insts.sail
@@ -1671,10 +1671,8 @@ function handle_loadres_data_via_cap(rd, auth_idx, auth_val, vaddrBits, width) =
   }
 }
 
-val handle_loadres_cap_via_cap : (regidx, capreg_idx, Capability, xlenbits) -> Retired effect {escape, rmem, rmemt, rreg, wmv, wmvt, wreg}
-function handle_loadres_cap_via_cap(cd, auth_idx, auth_val, vaddrBits) = {
-  let aq : bool = true;  /* cheri-specific aq/rl */
-  let rl : bool = true;
+val handle_loadres_cap_via_cap : (regidx, capreg_idx, Capability, xlenbits, bool, bool) -> Retired effect {escape, rmem, rmemt, rreg, wmv, wmvt, wreg}
+function handle_loadres_cap_via_cap(cd, auth_idx, auth_val, vaddrBits, aq, rl) = {
   let is_unsigned = false;
 if not(auth_val.tag) then {
     handle_cheri_cap_exception(CapEx_TagViolation, auth_idx);
@@ -1731,7 +1729,7 @@ function clause execute (LoadResCapDDC(cd, rs1)) = {
   if haveAtomics() then {
     let ddc_val = DDC;
     let vaddr = ddc_val.address + X(rs1);
-    handle_loadres_cap_via_cap(cd, DDC_IDX, ddc_val, vaddr)
+    handle_loadres_cap_via_cap(cd, DDC_IDX, ddc_val, vaddr, false, false)
   } else {
     handle_illegal();
     RETIRE_FAIL
@@ -1755,7 +1753,23 @@ function clause execute (LoadResCapCap(cd, cs1)) = {
   if haveAtomics() then {
     let cs1_val = C(cs1);
     let vaddr = cs1_val.address + X(cs1);
-    handle_loadres_cap_via_cap(cd, 0b0 @ cs1, cs1_val, vaddr)
+    handle_loadres_cap_via_cap(cd, 0b0 @ cs1, cs1_val, vaddr, false, false)
+  } else {
+    handle_illegal();
+    RETIRE_FAIL
+  }
+}
+
+
+union clause ast = LoadResCapMode : (regidx, regidx, bool, bool)
+/*
+ * Perform a load reserved of capability via either cs1 or DDC+rs1 depending
+ * on cap mode.
+ */
+function clause execute (LoadResCapMode(cd, rs1_cs1, aq, rl)) = {
+  if haveAtomics() then {
+    let (auth_val, vaddr, auth_idx) = get_cheri_mode_cap_addr(rs1_cs1, zeros());
+    handle_loadres_cap_via_cap(cd, auth_idx, auth_val, vaddr, aq, rl)
   } else {
     handle_illegal();
     RETIRE_FAIL
@@ -2068,11 +2082,9 @@ function handle_store_cond_data_via_cap(rs2, auth_idx, auth_val, vaddrBits, widt
   }
 }
 
-val handle_store_cond_cap_via_cap : (regidx, capreg_idx, Capability, xlenbits) -> Retired effect {eamem, escape, rmem, rmemt, rreg, wmv, wreg, wmvt}
-function handle_store_cond_cap_via_cap(cs2, auth_idx, auth_val, vaddrBits) = {
+val handle_store_cond_cap_via_cap : (regidx, regidx, capreg_idx, Capability, xlenbits, bool, bool) -> Retired effect {eamem, escape, rmem, rmemt, rreg, wmv, wreg, wmvt}
+function handle_store_cond_cap_via_cap(rd, cs2, auth_idx, auth_val, vaddrBits, aq, rl) = {
   let cs2_val = C(cs2);
-  let aq : bool = true; /* cheri-specific aq/rl */
-  let rl : bool = true;
   if not(auth_val.tag) then {
     handle_cheri_cap_exception(CapEx_TagViolation, auth_idx);
     RETIRE_FAIL
@@ -2096,7 +2108,7 @@ function handle_store_cond_cap_via_cap(cs2, auth_idx, auth_val, vaddrBits) = {
     RETIRE_FAIL
   } else if match_reservation(vaddrBits) == false then {
     /* cannot happen in rmem */
-    C(cs2) = int_to_cap(EXTZ(0b1));
+    X(rd) = EXTZ(0b1);
     cancel_reservation();
     RETIRE_SUCCESS
   } else {
@@ -2110,12 +2122,12 @@ function handle_store_cond_cap_via_cap(cs2, auth_idx, auth_val, vaddrBits) = {
             let res : MemoryOpResult(bool) = mem_write_cap(addr, cs2_val, aq, rl, false);
             match (res) {
               MemValue(true)  => {
-                 C(cs2) = int_to_cap(EXTZ(0b0));
+                 X(rd) = EXTZ(0b0);
                  cancel_reservation();
                  RETIRE_SUCCESS
               },
               MemValue(false) => {
-                 C(cs2) = int_to_cap(EXTZ(0b1));
+                 X(rd) = EXTZ(0b1);
                  cancel_reservation();
                  RETIRE_SUCCESS
               },
@@ -2160,7 +2172,7 @@ function clause execute StoreCondCapDDC(cs2, rs1) = {
   } else if haveAtomics() then {
     let ddc_val = DDC;
     let vaddr = ddc_val.address + X(rs1);
-    handle_store_cond_cap_via_cap(cs2, DDC_IDX, ddc_val, vaddr)
+    handle_store_cond_cap_via_cap(cs2, cs2, DDC_IDX, ddc_val, vaddr, false, false)
   } else {
     handle_illegal();
     RETIRE_FAIL
@@ -2196,7 +2208,92 @@ function clause execute StoreCondCapCap(cs2, cs1) = {
   } else if haveAtomics() then {
     let cs1_val = C(cs1);
     let vaddr = cs1_val.address;
-    handle_store_cond_cap_via_cap(cs2, 0b0 @ cs1, cs1_val, vaddr)
+    handle_store_cond_cap_via_cap(cs2, cs2, 0b0 @ cs1, cs1_val, vaddr, false, false)
+  } else {
+    handle_illegal();
+    RETIRE_FAIL
+  }
+}
+
+union clause ast = StoreCondCapMode : (regidx, regidx, regidx, bool, bool)
+function clause execute StoreCondCapMode(rd, cs2, rs1_cs1, aq, rl) = {
+  if speculate_conditional () == false then {
+    /* should only happen in rmem
+     * rmem: allow SC to fail very early
+     */
+    X(rd) = EXTZ(0b1);
+    RETIRE_SUCCESS
+  } else if haveAtomics() then {
+    let (auth_val, vaddr, auth_idx) = get_cheri_mode_cap_addr(rs1_cs1, zeros());
+    handle_store_cond_cap_via_cap(rd, cs2, auth_idx, auth_val, vaddr, aq, rl);
+  } else {
+    handle_illegal();
+    RETIRE_FAIL
+  }
+}
+
+union clause ast = AMOSwapCap : (regidx, regidx, regidx, bool, bool)
+function clause execute AMOSwapCap(cd, cs2, rs1_cs1, aq, rl) = {
+  if haveAtomics() then {
+    let (auth_val, vaddr, auth_idx) = get_cheri_mode_cap_addr(rs1_cs1, zeros());
+    let cs2_val = C(cs2);
+    if not(auth_val.tag) then {
+      handle_cheri_cap_exception(CapEx_TagViolation, auth_idx);
+      RETIRE_FAIL
+    } else if isCapSealed(auth_val) then {
+      handle_cheri_cap_exception(CapEx_SealViolation, auth_idx);
+      RETIRE_FAIL
+    } else if not (auth_val.permit_load) then {
+      handle_cheri_cap_exception(CapEx_PermitLoadViolation, auth_idx);
+      RETIRE_FAIL
+    } else if not (auth_val.permit_store) then {
+      handle_cheri_cap_exception(CapEx_PermitStoreViolation, auth_idx);
+      RETIRE_FAIL
+    } else if not (auth_val.permit_store_cap) & cs2_val.tag then {
+      handle_cheri_cap_exception(CapEx_PermitStoreCapViolation, auth_idx);
+      RETIRE_FAIL
+    } else if not (auth_val.permit_store_local_cap) & cs2_val.tag & not(cs2_val.global) then {
+      handle_cheri_cap_exception(CapEx_PermitStoreLocalCapViolation, auth_idx);
+      RETIRE_FAIL
+    } else if not(inCapBounds(auth_val, vaddr, cap_size)) then {
+      handle_cheri_cap_exception(CapEx_LengthViolation, auth_idx);
+      RETIRE_FAIL
+    } else if not(is_aligned_addr(vaddr, cap_size)) then {
+      handle_mem_exception(vaddr, E_SAMO_Addr_Align());
+      RETIRE_FAIL
+    } else {
+      match translateAddr(vaddr, ReadWrite(Cap, if cs2_val.tag then Cap else Data)) {
+        TR_Failure(e, _) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+        TR_Address(addr, ptw_info) => {
+          let eares : MemoryOpResult(unit) = mem_write_ea_cap(addr, aq, rl, false);
+          match (eares) {
+            MemException(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+            MemValue(_) => {
+              let c = mem_read_cap(addr, aq, rl, false);
+              match c {
+                MemValue(v) => {
+                  let wres : MemoryOpResult(bool) = mem_write_cap(addr, cs2_val, aq, rl, false);
+                  match wres {
+                    MemValue(_) => {
+                      let cr = if ptw_info.ptw_lc == PTW_LC_CLEAR
+                        then {v with tag = false} /* strip the tag */
+                        else {v with tag = v.tag & auth_val.permit_load_cap};
+                      C(cd) = cr;
+                      RETIRE_SUCCESS
+                    },
+                    MemException(e) => {
+                      handle_mem_exception(vaddr, e);
+                      RETIRE_FAIL
+                    }
+                  }
+                },
+                MemException(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL }
+              }
+            }
+          }
+        }
+      }
+    }
   } else {
     handle_illegal();
     RETIRE_FAIL
@@ -2421,3 +2518,16 @@ mapping clause encdec = StoreCapImm(cs2, rs1, off7 @ off5) if sizeof(xlen) == 32
 
 mapping clause assembly = LoadCapImm(cd, rs1, offset)   <-> "lc" ^ spc() ^ cap_reg_name(cd) ^ sep() ^ hex_bits_12(offset) ^ opt_spc() ^ "(" ^ opt_spc() ^ reg_name(rs1) ^ opt_spc() ^ ")"
 mapping clause assembly = StoreCapImm(cs2, rs1, offset) <-> "sc" ^ spc() ^ cap_reg_name(cs2) ^ sep() ^ hex_bits_12(offset) ^ opt_spc() ^ "(" ^ opt_spc() ^ reg_name(rs1) ^ opt_spc() ^ ")"
+
+mapping clause encdec = LoadResCapMode(cd, rs1, aq, rl) if sizeof(xlen) == 32 <-> 0b00010 @ bool_bits(aq) @ bool_bits(rl) @ 0b00000 @ rs1 @ 0b011 @ cd @ 0b0101111 if sizeof(xlen) == 32 /* lr.c (RV32) */
+mapping clause encdec = LoadResCapMode(cd, rs1, aq, rl) if sizeof(xlen) == 64 <-> 0b00010 @ bool_bits(aq) @ bool_bits(rl) @ 0b00000 @ rs1 @ 0b100 @ cd @ 0b0101111 if sizeof(xlen) == 64 /* lr.c (RV64) */
+
+mapping clause encdec = StoreCondCapMode(rd, cs2, rs1, aq, rl) if sizeof(xlen) == 32 <-> 0b00011 @ bool_bits(aq) @ bool_bits(rl) @ cs2 @ rs1 @ 0b011 @ rd @ 0b0101111 if sizeof(xlen) == 32 /* sc.c (RV32) */
+mapping clause encdec = StoreCondCapMode(rd, cs2, rs1, aq, rl) if sizeof(xlen) == 64 <-> 0b00011 @ bool_bits(aq) @ bool_bits(rl) @ cs2 @ rs1 @ 0b100 @ rd @ 0b0101111 if sizeof(xlen) == 64 /* sc.c (RV64) */
+
+mapping clause encdec = AMOSwapCap(cd, cs2, rs1, aq, rl) if sizeof(xlen) == 32 <-> 0b00001 @ bool_bits(aq) @ bool_bits(rl) @ cs2 @ rs1 @ 0b011 @ cd @ 0b0101111 if sizeof(xlen) == 32 /* sc.c (RV64) */
+mapping clause encdec = AMOSwapCap(cd, cs2, rs1, aq, rl) if sizeof(xlen) == 64 <-> 0b00001 @ bool_bits(aq) @ bool_bits(rl) @ cs2 @ rs1 @ 0b100 @ cd @ 0b0101111 if sizeof(xlen) == 64 /* sc.c (RV64) */
+
+mapping clause assembly = LoadResCapMode(cd, rs1, aq, rl) <-> "lr.c" ^ maybe_aq(aq) ^ maybe_rl(rl) ^ spc() ^ cap_reg_name(cd) ^ sep() ^ reg_name(rs1)
+mapping clause assembly = StoreCondCapMode(rd, cs2, rs1, aq, rl) <-> "sc.c" ^ maybe_aq(aq) ^ maybe_rl(rl) ^ spc() ^ reg_name(rd) ^ sep() ^ cap_reg_name(cs2) ^ sep() ^ reg_name(rs1)
+mapping clause assembly = AMOSwapCap(cd, cs2, rs1, aq, rl) <-> "amoswap.c" ^ maybe_aq(aq) ^ maybe_rl(rl) ^ spc() ^ cap_reg_name(cd) ^ sep() ^ cap_reg_name(cs2) ^ sep() ^ reg_name(rs1)

--- a/src/cheri_insts.sail
+++ b/src/cheri_insts.sail
@@ -2531,3 +2531,16 @@ mapping clause encdec = AMOSwapCap(cd, cs2, rs1, aq, rl) if sizeof(xlen) == 64 <
 mapping clause assembly = LoadResCapMode(cd, rs1, aq, rl) <-> "lr.c" ^ maybe_aq(aq) ^ maybe_rl(rl) ^ spc() ^ cap_reg_name(cd) ^ sep() ^ reg_name(rs1)
 mapping clause assembly = StoreCondCapMode(rd, cs2, rs1, aq, rl) <-> "sc.c" ^ maybe_aq(aq) ^ maybe_rl(rl) ^ spc() ^ reg_name(rd) ^ sep() ^ cap_reg_name(cs2) ^ sep() ^ reg_name(rs1)
 mapping clause assembly = AMOSwapCap(cd, cs2, rs1, aq, rl) <-> "amoswap.c" ^ maybe_aq(aq) ^ maybe_rl(rl) ^ spc() ^ cap_reg_name(cd) ^ sep() ^ cap_reg_name(cs2) ^ sep() ^ reg_name(rs1)
+
+/* 
+  CHERI really needs sub word atomic operations because bounds checks mean you
+  can't implement them in software with word sized operations. The RISC-V 
+  spec. does not define lr / sc for bytes or half words although the obvious 
+  encodings are vacant. Since the base Sail model actually implements the unused 
+  widths but refuses to decode them we can implement them for CHERI simply by 
+  adding the decodings here.
+*/
+mapping clause encdec = LOADRES(aq, rl, rs1, size, rd) if (size == BYTE) | (size == HALF)
+  <-> 0b00010 @ bool_bits(aq) @ bool_bits(rl) @ 0b00000 @ rs1 @ 0b0 @ size_bits(size) @ rd @ 0b0101111 if (size == BYTE) | (size == HALF)
+mapping clause encdec = STORECON(aq, rl, rs2, rs1, size, rd) if (size == BYTE) | (size == HALF)
+  <-> 0b00011 @ bool_bits(aq) @ bool_bits(rl) @ rs2 @ rs1 @ 0b0 @ size_bits(size) @ rd @ 0b0101111 if (size == BYTE) | (size == HALF)

--- a/src/cheri_insts.sail
+++ b/src/cheri_insts.sail
@@ -1392,10 +1392,10 @@ function handle_load_data_via_cap(rd, auth_idx, auth_val, vaddrBits, is_unsigned
     TR_Failure(e, _) => { handle_mem_exception(vaddrBits, e); RETIRE_FAIL },
     TR_Address(addr, _) =>
       match (width, sizeof(xlen)) {
-        (BYTE, _)    => process_load(rd, vaddrBits, mem_read(Read(Data), addr, 1, aq, rl, false), is_unsigned),
-        (HALF, _)    => process_load(rd, vaddrBits, mem_read(Read(Data), addr, 2, aq, rl, false), is_unsigned),
-        (WORD, _)    => process_load(rd, vaddrBits, mem_read(Read(Data), addr, 4, aq, rl, false), is_unsigned),
-        (DOUBLE, 64) => process_load(rd, vaddrBits, mem_read(Read(Data), addr, 8, aq, rl, false), is_unsigned)
+        (BYTE, _)    => process_load(rd, vaddrBits, mem_read(Read(Data), addr, 1, aq, aq & rl, false), is_unsigned),
+        (HALF, _)    => process_load(rd, vaddrBits, mem_read(Read(Data), addr, 2, aq, aq & rl, false), is_unsigned),
+        (WORD, _)    => process_load(rd, vaddrBits, mem_read(Read(Data), addr, 4, aq, aq & rl, false), is_unsigned),
+        (DOUBLE, 64) => process_load(rd, vaddrBits, mem_read(Read(Data), addr, 8, aq, aq & rl, false), is_unsigned)
       }
   }
 }
@@ -1464,7 +1464,7 @@ function handle_load_cap_via_cap(cd, auth_idx, auth_val, vaddrBits) = {
     TR_Failure(E_Extension(_), _) => { internal_error("unexpected cheri exception for cap load") },
     TR_Failure(e, _) => { handle_mem_exception(vaddrBits, e); RETIRE_FAIL },
     TR_Address(addr, ptw_info) => {
-      let c = mem_read_cap(addr, aq, rl, false);
+      let c = mem_read_cap(addr, aq, aq & rl, false);
       match c {
         MemValue(v) => {
           let cr = if ptw_info.ptw_lc == PTW_LC_CLEAR
@@ -1610,7 +1610,7 @@ function clause execute (CLoadTags(rd, cs1)) = {
           match mtags {
             MemException(_) => (),
             MemValue(tags) => {
-              match mem_read_cap(addr + i * cap_size, aq, rl, false) {
+              match mem_read_cap(addr + i * cap_size, aq, aq & rl, false) {
                 MemException(e) => mtags = MemException(e),
                 MemValue(v) =>
                   mtags = MemValue([tags with i = bool_to_bit(v.tag)])
@@ -1663,10 +1663,10 @@ function handle_loadres_data_via_cap(rd, auth_idx, auth_val, vaddrBits, width) =
     TR_Failure(e, _) => { handle_mem_exception(vaddrBits, e); RETIRE_FAIL },
     TR_Address(addr, _) =>
       match (width, sizeof(xlen)) {
-        (BYTE, _)    => process_loadres(rd, vaddrBits, mem_read(Read(Data), addr, 1, aq, rl, false), is_unsigned),
-        (HALF, _)    => process_loadres(rd, vaddrBits, mem_read(Read(Data), addr, 2, aq, rl, false), is_unsigned),
-        (WORD, _)    => process_loadres(rd, vaddrBits, mem_read(Read(Data), addr, 4, aq, rl, false), is_unsigned),
-        (DOUBLE, 64) => process_loadres(rd, vaddrBits, mem_read(Read(Data), addr, 8, aq, rl, false), is_unsigned)
+        (BYTE, _)    => process_loadres(rd, vaddrBits, mem_read(Read(Data), addr, 1, aq, aq & rl, false), is_unsigned),
+        (HALF, _)    => process_loadres(rd, vaddrBits, mem_read(Read(Data), addr, 2, aq, aq & rl, false), is_unsigned),
+        (WORD, _)    => process_loadres(rd, vaddrBits, mem_read(Read(Data), addr, 4, aq, aq & rl, false), is_unsigned),
+        (DOUBLE, 64) => process_loadres(rd, vaddrBits, mem_read(Read(Data), addr, 8, aq, aq & rl, false), is_unsigned)
       }
   }
 }
@@ -1693,7 +1693,7 @@ if not(auth_val.tag) then {
     TR_Failure(E_Extension(_), _) => { internal_error("unexpected cheri exception for cap load") },
     TR_Failure(e, _) => { handle_mem_exception(vaddrBits, e); RETIRE_FAIL },
     TR_Address(addr, ptw_info) => {
-      let c = mem_read_cap(addr, aq, rl, false);
+      let c = mem_read_cap(addr, aq, aq & rl, false);
       match c {
         MemValue(v) => {
           let cr = if ptw_info.ptw_lc == PTW_LC_CLEAR
@@ -1800,16 +1800,16 @@ function handle_store_data_via_cap(rs2, auth_idx, auth_val, vaddrBits, width) = 
     TR_Failure(E_Extension(_), _) => { internal_error("unexpected cheri exception for data store") },
     TR_Failure(e, _) => { handle_mem_exception(vaddrBits, e); RETIRE_FAIL },
     TR_Address(addr, _) => {
-      let eares : MemoryOpResult(unit) = mem_write_ea(addr, size, aq, rl, false);
+      let eares : MemoryOpResult(unit) = mem_write_ea(addr, size, aq & rl, rl, false);
       match (eares) {
         MemException(e) => { handle_mem_exception(vaddrBits, e); RETIRE_FAIL },
         MemValue(_) => {
           let rs2_val = X(rs2);
           let res : MemoryOpResult(bool) = match (width, sizeof(xlen)) {
-            (BYTE, _)     => mem_write_value(addr, 1, rs2_val[7..0],  aq, rl, false),
-            (HALF, _)     => mem_write_value(addr, 2, rs2_val[15..0], aq, rl, false),
-            (WORD, _)     => mem_write_value(addr, 4, rs2_val[31..0], aq, rl, false),
-            (DOUBLE, 64) => mem_write_value(addr, 8, rs2_val,        aq, rl, false)
+            (BYTE, _)     => mem_write_value(addr, 1, rs2_val[7..0],  aq & rl, rl, false),
+            (HALF, _)     => mem_write_value(addr, 2, rs2_val[15..0], aq & rl, rl, false),
+            (WORD, _)     => mem_write_value(addr, 4, rs2_val[31..0], aq & rl, rl, false),
+            (DOUBLE, 64) => mem_write_value(addr, 8, rs2_val,        aq & rl, rl, false)
           };
           match (res) {
             MemValue(true)  => RETIRE_SUCCESS,
@@ -1891,11 +1891,11 @@ function handle_store_cap_via_cap(cs2, auth_idx, auth_val, vaddrBits) = {
   } else match translateAddr(vaddrBits, Write(if cs2_val.tag then Cap else Data)) {
     TR_Failure(e, _) => { handle_mem_exception(vaddrBits, e); RETIRE_FAIL },
     TR_Address(addr, _) => {
-      let eares : MemoryOpResult(unit) = mem_write_ea_cap(addr, aq, rl, false);
+      let eares : MemoryOpResult(unit) = mem_write_ea_cap(addr, aq & rl, rl, false);
       match (eares) {
         MemException(e) => { handle_mem_exception(vaddrBits, e); RETIRE_FAIL },
         MemValue(_) => {
-          let res : MemoryOpResult(bool) = mem_write_cap(addr, cs2_val, aq, rl, false);
+          let res : MemoryOpResult(bool) = mem_write_cap(addr, cs2_val, aq & rl, rl, false);
           match (res) {
             MemValue(true)  => RETIRE_SUCCESS,
             MemValue(false) => internal_error("store got false from mem_write_value"),
@@ -2059,16 +2059,16 @@ function handle_store_cond_data_via_cap(rs2, auth_idx, auth_val, vaddrBits, widt
       TR_Failure(E_Extension(_), _) => { internal_error("unexpected cheri exception for data store") },
       TR_Failure(e, _) => { handle_mem_exception(vaddrBits, e); RETIRE_FAIL },
       TR_Address(addr, _) => {
-        let eares : MemoryOpResult(unit) = mem_write_ea(addr, size, aq, rl, false);
+        let eares : MemoryOpResult(unit) = mem_write_ea(addr, size, aq & rl, rl, false);
         match (eares) {
           MemException(e) => { handle_mem_exception(vaddrBits, e); RETIRE_FAIL },
           MemValue(_) => {
             let rs2_val = X(rs2);
             let res : MemoryOpResult(bool) = match (width, sizeof(xlen)) {
-              (BYTE, _)     => mem_write_value(addr, 1, rs2_val[7..0],  aq, rl, false),
-              (HALF, _)     => mem_write_value(addr, 2, rs2_val[15..0], aq, rl, false),
-              (WORD, _)     => mem_write_value(addr, 4, rs2_val[31..0], aq, rl, false),
-              (DOUBLE, 64)  => mem_write_value(addr, 8, rs2_val,        aq, rl, false)
+              (BYTE, _)     => mem_write_value(addr, 1, rs2_val[7..0],  aq & rl, rl, false),
+              (HALF, _)     => mem_write_value(addr, 2, rs2_val[15..0], aq & rl, rl, false),
+              (WORD, _)     => mem_write_value(addr, 4, rs2_val[31..0], aq & rl, rl, false),
+              (DOUBLE, 64)  => mem_write_value(addr, 8, rs2_val,        aq & rl, rl, false)
             };
             match (res) {
               MemValue(true)  => { X(rs2) = EXTZ(0b0); cancel_reservation(); RETIRE_SUCCESS },
@@ -2129,11 +2129,11 @@ function handle_store_cond_cap_via_cap(rd, cs2, auth_idx, auth_val, vaddrBits, a
     match translateAddr(vaddrBits, Write(if cs2_val.tag then Cap else Data)) {
       TR_Failure(e, _) => { handle_mem_exception(vaddrBits, e); RETIRE_FAIL },
       TR_Address(addr, _) => {
-        let eares : MemoryOpResult(unit) = mem_write_ea_cap(addr, aq, rl, false);
+        let eares : MemoryOpResult(unit) = mem_write_ea_cap(addr, aq & rl, rl, false);
         match (eares) {
           MemException(e) => { handle_mem_exception(vaddrBits, e); RETIRE_FAIL },
           MemValue(_) => {
-            let res : MemoryOpResult(bool) = mem_write_cap(addr, cs2_val, aq, rl, false);
+            let res : MemoryOpResult(bool) = mem_write_cap(addr, cs2_val, aq & rl, rl, false);
             match (res) {
               MemValue(true)  => {
                 write_sc_cap_result(rd, cap_dest, 0b0);
@@ -2279,14 +2279,14 @@ function clause execute AMOSwapCap(cd, cs2, rs1_cs1, aq, rl) = {
       match translateAddr(vaddr, ReadWrite(Cap, if cs2_val.tag then Cap else Data)) {
         TR_Failure(e, _) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
         TR_Address(addr, ptw_info) => {
-          let eares : MemoryOpResult(unit) = mem_write_ea_cap(addr, aq, rl, false);
+          let eares : MemoryOpResult(unit) = mem_write_ea_cap(addr, aq & rl, rl, false);
           match (eares) {
             MemException(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
             MemValue(_) => {
-              let c = mem_read_cap(addr, aq, rl, false);
+              let c = mem_read_cap(addr, aq, aq & rl, false);
               match c {
                 MemValue(v) => {
-                  let wres : MemoryOpResult(bool) = mem_write_cap(addr, cs2_val, aq, rl, false);
+                  let wres : MemoryOpResult(bool) = mem_write_cap(addr, cs2_val, aq & rl, rl, false);
                   match wres {
                     MemValue(_) => {
                       let cr = if ptw_info.ptw_lc == PTW_LC_CLEAR

--- a/src/cheri_insts.sail
+++ b/src/cheri_insts.sail
@@ -2082,8 +2082,22 @@ function handle_store_cond_data_via_cap(rs2, auth_idx, auth_val, vaddrBits, widt
   }
 }
 
-val handle_store_cond_cap_via_cap : (regidx, regidx, capreg_idx, Capability, xlenbits, bool, bool) -> Retired effect {eamem, escape, rmem, rmemt, rreg, wmv, wreg, wmvt}
-function handle_store_cond_cap_via_cap(rd, cs2, auth_idx, auth_val, vaddrBits, aq, rl) = {
+function write_sc_cap_result(rd : regidx, cap_dest : bool, result : bits(1)) -> unit = {
+  /* Some SC instructions re-use the source register as the destination. To 
+    ensure this works correctly for split register file implementations we
+    need to be careful about writing to the correct register file. This is only
+    a concern for store conditional of capabilities where the source register 
+    is a capability register but the destination may be either a capability or
+    an general purpose register depending on the instruction. */
+  if cap_dest then {
+    C(rd) = int_to_cap(EXTZ(result));
+  } else {
+    X(rd) = EXTZ(result);
+  }
+}
+
+val handle_store_cond_cap_via_cap : (regidx, regidx, capreg_idx, Capability, xlenbits, bool, bool, bool) -> Retired effect {eamem, escape, rmem, rmemt, rreg, wmv, wreg, wmvt}
+function handle_store_cond_cap_via_cap(rd, cs2, auth_idx, auth_val, vaddrBits, aq, rl, cap_dest) = {
   let cs2_val = C(cs2);
   if not(auth_val.tag) then {
     handle_cheri_cap_exception(CapEx_TagViolation, auth_idx);
@@ -2108,7 +2122,7 @@ function handle_store_cond_cap_via_cap(rd, cs2, auth_idx, auth_val, vaddrBits, a
     RETIRE_FAIL
   } else if match_reservation(vaddrBits) == false then {
     /* cannot happen in rmem */
-    X(rd) = EXTZ(0b1);
+    write_sc_cap_result(rd, cap_dest, 0b1);
     cancel_reservation();
     RETIRE_SUCCESS
   } else {
@@ -2122,14 +2136,14 @@ function handle_store_cond_cap_via_cap(rd, cs2, auth_idx, auth_val, vaddrBits, a
             let res : MemoryOpResult(bool) = mem_write_cap(addr, cs2_val, aq, rl, false);
             match (res) {
               MemValue(true)  => {
-                 X(rd) = EXTZ(0b0);
-                 cancel_reservation();
-                 RETIRE_SUCCESS
+                write_sc_cap_result(rd, cap_dest, 0b0);
+                cancel_reservation();
+                RETIRE_SUCCESS
               },
               MemValue(false) => {
-                 X(rd) = EXTZ(0b1);
-                 cancel_reservation();
-                 RETIRE_SUCCESS
+                write_sc_cap_result(rd, cap_dest, 0b1);
+                cancel_reservation();
+                RETIRE_SUCCESS
               },
               MemException(e) => {
                 handle_mem_exception(vaddrBits, e);
@@ -2172,7 +2186,7 @@ function clause execute StoreCondCapDDC(cs2, rs1) = {
   } else if haveAtomics() then {
     let ddc_val = DDC;
     let vaddr = ddc_val.address + X(rs1);
-    handle_store_cond_cap_via_cap(cs2, cs2, DDC_IDX, ddc_val, vaddr, false, false)
+    handle_store_cond_cap_via_cap(cs2, cs2, DDC_IDX, ddc_val, vaddr, false, false, true)
   } else {
     handle_illegal();
     RETIRE_FAIL
@@ -2208,7 +2222,7 @@ function clause execute StoreCondCapCap(cs2, cs1) = {
   } else if haveAtomics() then {
     let cs1_val = C(cs1);
     let vaddr = cs1_val.address;
-    handle_store_cond_cap_via_cap(cs2, cs2, 0b0 @ cs1, cs1_val, vaddr, false, false)
+    handle_store_cond_cap_via_cap(cs2, cs2, 0b0 @ cs1, cs1_val, vaddr, false, false, true)
   } else {
     handle_illegal();
     RETIRE_FAIL
@@ -2225,7 +2239,7 @@ function clause execute StoreCondCapMode(rd, cs2, rs1_cs1, aq, rl) = {
     RETIRE_SUCCESS
   } else if haveAtomics() then {
     let (auth_val, vaddr, auth_idx) = get_cheri_mode_cap_addr(rs1_cs1, zeros());
-    handle_store_cond_cap_via_cap(rd, cs2, auth_idx, auth_val, vaddr, aq, rl);
+    handle_store_cond_cap_via_cap(rd, cs2, auth_idx, auth_val, vaddr, aq, rl, false);
   } else {
     handle_illegal();
     RETIRE_FAIL


### PR DESCRIPTION
Partially fixes #46 . It is only partial because `{lr, sc}.{b, h}` still have to be implemented. The will require a tweak to the sail-riscv spec.