### PR TITLE
Github action

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -18,5 +18,5 @@ jobs:
       uses: actions/checkout@HEAD
       with:
         submodules: true
-    - name: Build model
-      run: eval $(opam env) && make -d csim
+    - name: Build simulators
+      run: eval $(opam env) && make -j4 c_emulator/cheri_riscv_{sim,rvfi}_RV{32,64}

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: [ubuntu-18.04]
+    steps:
+    - name: Install opam2
+      run: |
+        sudo add-apt-repository -y ppa:avsm/ppa
+        sudo apt install -y opam zlib1g-dev pkg-config libgmp-dev z3
+    - name: Init opam
+      run: opam init --disable-sandboxing -y
+    - name: Install sail
+      run: opam install -y sail
+    - name: Check out repository code
+      uses: actions/checkout@HEAD
+      with:
+        submodules: true
+    - name: Build model
+      run: eval $(opam env) && make -d csim


### PR DESCRIPTION
This adds a github action that builds the C emulators for RV32 and RV64, normal and rvfi on each push. Unfortunately compiling sail and install its dependencies each time takes a while and is quite inefficient. We might be able to use a docker file to improve on this but I've not figured out how yet. Fortunately pushes are not that frequent. 