### PR TITLE
Update sail-riscv submodule and adjust Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,9 +299,25 @@ c_emulator/cheri_riscv_sim_%: generated_definitions/c/riscv_model_%.c $(SAIL_RIS
 	mkdir -p c_emulator
 	gcc -g $(C_WARNINGS) $(C_FLAGS) $< $(SAIL_RISCV_DIR)/c_emulator/riscv_sim.c $(C_SRCS) $(SAIL_LIB_DIR)/*.c $(C_LIBS) -o $@
 
+# Note: We have to add -c_preserve since the functions might be optimized out otherwise
+rvfi_preserve_fns=-c_preserve rvfi_set_instr_packet \
+  -c_preserve rvfi_get_cmd \
+  -c_preserve rvfi_get_insn \
+  -c_preserve rvfi_get_v2_trace_size \
+  -c_preserve rvfi_get_v2_support_packet \
+  -c_preserve rvfi_get_exec_packet_v1 \
+  -c_preserve rvfi_get_exec_packet_v2 \
+  -c_preserve rvfi_get_mem_data \
+  -c_preserve rvfi_get_int_data \
+  -c_preserve rvfi_zero_exec_packet \
+  -c_preserve rvfi_halt_exec_packet \
+  -c_preserve print_rvfi_exec \
+  -c_preserve print_instr_packet \
+  -c_preserve print_rvfi_exec
+
 generated_definitions/c/riscv_rvfi_model_%.c: $(SAIL_RVFI_SRCS) $(SAIL_RISCV_MODEL_DIR)/main.sail Makefile
 	mkdir -p generated_definitions/c
-	$(SAIL) $(SAIL_FLAGS) -O -Oconstant_fold -memo_z3 -c -c_include riscv_prelude.h -c_include riscv_platform.h -c_no_main $(SAIL_RVFI_SRCS) $(SAIL_RISCV_MODEL_DIR)/main.sail -o $(basename $@)
+	$(SAIL) $(rvfi_preserve_fns) $(SAIL_FLAGS) -O -Oconstant_fold -memo_z3 -c -c_include riscv_prelude.h -c_include riscv_platform.h -c_no_main $(SAIL_RVFI_SRCS) $(SAIL_RISCV_MODEL_DIR)/main.sail -o $(basename $@)
 
 c_emulator/cheri_riscv_rvfi_%: generated_definitions/c/riscv_rvfi_model_%.c $(SAIL_RISCV_DIR)/c_emulator/riscv_sim.c $(C_INCS) $(C_SRCS) $(SOFTFLOAT_LIBS) Makefile
 	mkdir -p c_emulator


### PR DESCRIPTION
This adds the new RVFI tracing format and various other improvements.