### PR TITLE
Catch up with upstream sail-riscv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,15 +12,13 @@ SAIL_RISCV_MODEL_DIR=$(SAIL_RISCV_DIR)/model
 SAIL_CHERI_MODEL_DIR=src
 
 SAIL_RV32_XLEN := $(SAIL_RISCV_MODEL_DIR)/riscv_xlen32.sail
-SAIL_RV32_FLEN := $(SAIL_RISCV_MODEL_DIR)/riscv_flen_F.sail
 CHERI_CAP_RV32_IMPL := cheri_prelude_64.sail
 
 SAIL_RV64_XLEN := $(SAIL_RISCV_MODEL_DIR)/riscv_xlen64.sail
-SAIL_RV64_FLEN := $(SAIL_RISCV_MODEL_DIR)/riscv_flen_D.sail
 CHERI_CAP_RV64_IMPL := cheri_prelude_128.sail
 
 SAIL_XLEN = $(SAIL_$(ARCH)_XLEN)
-SAIL_FLEN = $(SAIL_$(ARCH)_FLEN)
+SAIL_FLEN = $(SAIL_RISCV_MODEL_DIR)/riscv_flen_D.sail
 CHERI_CAP_IMPL = $(CHERI_CAP_$(ARCH)_IMPL)
 
 
@@ -191,7 +189,7 @@ GMP_LIBS := $(shell pkg-config --libs gmp || echo -lgmp)
 ZLIB_FLAGS = $(shell pkg-config --cflags zlib)
 ZLIB_LIBS = $(shell pkg-config --libs zlib)
 
-C_FLAGS = -I $(SAIL_LIB_DIR) -I $(SAIL_RISCV_DIR)/c_emulator $(GMP_FLAGS) $(ZLIB_FLAGS) $(SOFTFLOAT_FLAGS)
+C_FLAGS = -I $(SAIL_LIB_DIR) -I $(SAIL_RISCV_DIR)/c_emulator $(GMP_FLAGS) $(ZLIB_FLAGS) $(SOFTFLOAT_FLAGS) -fcommon
 C_LIBS  = $(GMP_LIBS) $(ZLIB_LIBS) $(SOFTFLOAT_LIBS)
 
 ifneq (,$(SAILCOV))

--- a/src/cheri_addr_checks.sail
+++ b/src/cheri_addr_checks.sail
@@ -212,6 +212,12 @@ function ext_handle_data_check_error(err : ext_data_addr_error) -> unit = {
   handle_cheri_cap_exception(capEx, regnum)
 }
 
+/* Default implementations of these hooks permit all accesses.  */
+function ext_check_phys_mem_read (access_type, paddr, size, aquire, release, reserved, read_meta) =
+  Ext_PhysAddr_OK()
+
+function ext_check_phys_mem_write(write_kind, paddr, size, data, metadata) =
+  Ext_PhysAddr_OK()
 
 /* Is XRET from given mode permitted by extension? */
 function ext_check_xret_priv (p : Privilege) : Privilege -> bool =


### PR DESCRIPTION
Pull up to
https://github.com/riscv/sail-riscv/commit/2265a2576fac6d555cfc5f850f78e79c2da56312

Some upstream changes apply to files in this repository as well:

- Following along with
https://github.com/riscv/sail-riscv/commit/b1db5b944b42062d063343db8e2efd05e5889b21
add ext_check_phys_mem_read and ext_check_phys_mem_write implementations.

- Following along with
https://github.com/riscv/sail-riscv/commit/9b38e33c766c7c0397b9d51bf91544db391be670
always use riscv_flen_D.sail rather than riscv_flen_F.sail on RV32.

- Following along with
https://github.com/riscv/sail-riscv/commit/ffea7a39c32a210a446379aeda0eabcec4918ed6
use -fcommon in C_FLAGS.