### PR TITLE
Add bool for writing to destination reg to RVFI output

### DIFF
--- a/src/cheri_insts.sail
+++ b/src/cheri_insts.sail
@@ -783,7 +783,7 @@ function clause execute (CClear(q, m)) = {
       if q_u == 0 & i == 0 then
         DDC = null_cap
       else
-        C(8 * q_u + i) = null_cap;
+        wC (false, 8 * q_u + i, null_cap);
   RETIRE_SUCCESS
 }
 

--- a/src/cheri_regs.sail
+++ b/src/cheri_regs.sail
@@ -103,8 +103,8 @@ function rC r = {
 }
 
 /* writes a register with a capability value */
-val wC : forall 'n, 0 <= 'n < 32. (regno('n), regtype) -> unit effect {wreg, escape}
-function wC (r, v) = {
+val wC : forall 'n, 0 <= 'n < 32. (bool, regno('n), regtype) -> unit effect {wreg, escape}
+function wC (b, r, v) = {
   match r {
     0  => (),
     1  => x1 = v,
@@ -141,7 +141,8 @@ function wC (r, v) = {
     _  => internal_error("Invalid capability register")
   };
   if (r != 0) then {
-     rvfi_wX(r, v.address);
+     if b then
+       rvfi_wX(r, v.address);
      if get_config_print_reg() then
        print_reg("x" ^ string_of_int(r) ^ " <- " ^ RegStr(v));
   }
@@ -149,9 +150,12 @@ function wC (r, v) = {
 
 function rC_bits(r: bits(5)) -> regtype = rC(unsigned(r))
 
-function wC_bits(r: bits(5), v: regtype) -> unit = wC(unsigned(r), v)
+function wC_bits(r: bits(5), v: regtype) -> unit = wC (true, unsigned(r), v)
 
-overload C = {rC_bits, wC_bits, rC, wC}
+val wC_rvfi : forall 'n, 0 <= 'n < 32. (regno('n), regtype) -> unit effect {wreg, escape}
+function wC_rvfi (r, v) = wC (true, r, v)
+
+overload C = {rC_bits, wC_bits, rC, wC_rvfi}
 
 val ext_init_regs : unit -> unit effect {wreg}
 function ext_init_regs () = {


### PR DESCRIPTION
In sail, when an instruction writes to a register, the register number will also be written to the `rvfi_rd_addr` field (if it has been built for RVFI output). When an instruction has no destination register, the `rvfi_rd_addr` remains zero. The CClear instruction in the CHERI is an exception to the regular RISC-V instruction format. It can write to up to eight registers. However, CClear has no destination register, but rather a two-bit immediate determining which quarter of the register file this instruction will write to.

Currently, the sail implementation for CClear writes the highest register number to `rvfi_rd_addr`. This PR changes this behaviour and never writes a destination register to the field, which results in the field containing zeros. I think this is the correct behaviour for the model as the `rvfi_rd_addr` field cannot correctly represent the destination register behaviour of CClear.