### PR TITLE
Don't print CHERI exceptions unconditionally

### DIFF
--- a/src/cheri_addr_checks.sail
+++ b/src/cheri_addr_checks.sail
@@ -66,7 +66,7 @@ val handle_cheri_cap_exception : (CapEx, capreg_idx) -> unit effect {escape, rre
 function handle_cheri_cap_exception(capEx, regnum) =
   {
     if get_config_print_platform()
-    then print("CHERI " ^ string_of_capex(capEx) ^ " Reg=" ^ BitStr(regnum));
+    then print_platform("CHERI " ^ string_of_capex(capEx) ^ " Reg=" ^ BitStr(regnum));
     let t : sync_exception = struct {
       trap    = E_Extension(EXC_CHERI),
       excinfo = Some(EXTZ(regnum @ CapExCode(capEx)) : xlenbits),

--- a/src/cheri_addr_checks.sail
+++ b/src/cheri_addr_checks.sail
@@ -65,7 +65,8 @@
 val handle_cheri_cap_exception : (CapEx, capreg_idx) -> unit effect {escape, rreg, wreg}
 function handle_cheri_cap_exception(capEx, regnum) =
   {
-    print("CHERI " ^ string_of_capex(capEx) ^ " Reg=" ^ BitStr(regnum));
+    if get_config_print_platform()
+    then print("CHERI " ^ string_of_capex(capEx) ^ " Reg=" ^ BitStr(regnum));
     let t : sync_exception = struct {
       trap    = E_Extension(EXC_CHERI),
       excinfo = Some(EXTZ(regnum @ CapExCode(capEx)) : xlenbits),


### PR DESCRIPTION
Guard this with get_config_print_platform() to match other exception information print calls.