### PR TITLE
Sync default instructions list with sail-riscv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,13 @@ SAIL_DEFAULT_INST = $(SAIL_RISCV_MODEL_DIR)/riscv_insts_base.sail \
                     $(SAIL_RISCV_MODEL_DIR)/riscv_insts_aext.sail \
                     $(SAIL_RISCV_MODEL_DIR)/riscv_insts_cext.sail \
                     $(SAIL_RISCV_MODEL_DIR)/riscv_insts_mext.sail \
+                    $(SAIL_RISCV_MODEL_DIR)/riscv_insts_next.sail \
+                    $(SAIL_RISCV_MODEL_DIR)/riscv_insts_hints.sail \
                     $(SAIL_RISCV_MODEL_DIR)/riscv_insts_zicsr.sail \
                     $(SAIL_RISCV_MODEL_DIR)/riscv_insts_fext.sail \
+                    $(SAIL_RISCV_MODEL_DIR)/riscv_insts_cfext.sail \
                     $(SAIL_RISCV_MODEL_DIR)/riscv_insts_dext.sail \
+                    $(SAIL_RISCV_MODEL_DIR)/riscv_insts_cdext.sail \
                     $(SAIL_CHERI_MODEL_DIR)/cheri_insts.sail
 SAIL_SEQ_INST  = $(SAIL_DEFAULT_INST) $(SAIL_RISCV_MODEL_DIR)/riscv_jalr_seq.sail
 SAIL_RMEM_INST = $(SAIL_DEFAULT_INST) $(SAIL_RISCV_MODEL_DIR)/riscv_jalr_rmem.sail $(SAIL_RISCV_MODEL_DIR)/riscv_insts_rmem.sail


### PR DESCRIPTION
This does not yet include any of the Zb* or Zk* instructions, but adds various compressed instructions (e.g. hints) that I noticed were missing while fuzzing against QEMU.

Counter-example trace:
```
.4byte 0x00000062 # SLLI hint
#  A < Trap:  True, PCWD: 0x0000000000000000, RD: 00, RWD: 0x0000000000000000, MA: 0x0000000000000000, MWD: 0x0000000000000000, MWM: 0b00000000, I: 0x0000000000000069 PRV_M XL:64 (Unknown instruction)
#  B > Trap: False, PCWD: 0x0000000080000002, RD: 00, RWD: 0x0000000000000000, MA: 0x0000000000000000, MWD: 0x0000000000000000, MWM: 0b00000000, I: 0x0000000000000069 PRV_M XL:64 (Unknown instruction)
.assert rd_wdata == 0x0 "hint"
```