### PR TITLE
The github 18.04 action runner is deprecated so upgrade to 20.04.

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -4,14 +4,13 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-20.04]
     steps:
     - name: Install opam2
       run: |
-        sudo add-apt-repository -y ppa:avsm/ppa
         sudo apt install -y opam zlib1g-dev pkg-config libgmp-dev z3
     - name: Init opam
-      run: opam init --disable-sandboxing -y
+      run: opam init -y
     - name: Install sail
       run: opam install -y sail
     - name: Check out repository code


### PR DESCRIPTION
 As a bonus opam2 is now available in apt so we can drop the PPA. I think --disable-sandboxing is also no longer required.