### PR TITLE
Allocate a feature bit in xCCSR to report tag-clearing semantics

### DIFF
--- a/src/cheri_regs.sail
+++ b/src/cheri_regs.sail
@@ -209,10 +209,13 @@ function ext_init_regs () = {
   misa->X() = 0b1;
   mccsr->d() = 0b1;
   mccsr->e() = 0b1;
+  mccsr->tc() = 0b1;
   sccsr->d() = 0b1;
   sccsr->e() = 0b1;
+  sccsr->tc() = 0b1;
   uccsr->d() = 0b1;
   uccsr->e() = 0b1;
+  uccsr->tc() = 0b1;
 }
 
 /*!

--- a/src/cheri_sys_regs.sail
+++ b/src/cheri_sys_regs.sail
@@ -65,6 +65,8 @@
 /* Capability control csr */
 
 bitfield ccsr : xlenbits = {
+  /* Bits allocated from 31 downwards are used for feature flags. */
+  tc      :  31,     /* tag-clearing error semantics */
   d       :  1,      /* dirty  */
   e       :  0       /* enable */
 }
@@ -84,6 +86,7 @@ function legalize_ccsr(c : ccsr, v : xlenbits) -> ccsr = {
   /* For now these bits are not really supported so hardwired to true */
   let c = update_d(c, 0b1);
   let c = update_e(c, 0b1);
+  let c = update_tc(c, 0b1);
   c
 }
 


### PR DESCRIPTION
This can be used by CheriBSD to probe the underlying CHERI semantics while there are still multiple incompatible versions. In the longer term, this register is unlikely to be part of a standardized RISC-V extension, so allocating bits for temporary transitions should be fine.