### PR TITLE
Remove the d bit from xccsr

### DIFF
--- a/src/cheri_regs.sail
+++ b/src/cheri_regs.sail
@@ -207,15 +207,9 @@ function ext_init_regs () = {
   x31 = null_cap;
 
   misa->X() = 0b1;
-  mccsr->d() = 0b1;
-  mccsr->e() = 0b1;
-  mccsr->tc() = 0b1;
-  sccsr->d() = 0b1;
-  sccsr->e() = 0b1;
-  sccsr->tc() = 0b1;
-  uccsr->d() = 0b1;
-  uccsr->e() = 0b1;
-  uccsr->tc() = 0b1;
+  mccsr = legalize_ccsr(mccsr, zeros());
+  sccsr = legalize_ccsr(sccsr, zeros());
+  uccsr = legalize_ccsr(uccsr, zeros());
 }
 
 /*!

--- a/src/cheri_step_ext.sail
+++ b/src/cheri_step_ext.sail
@@ -65,12 +65,9 @@
 val ext_init : unit -> unit effect {wreg}
 function ext_init () = {
   misa->X() = 0b1;
-  mccsr->d() = 0b1;
-  mccsr->e() = 0b1;
-  sccsr->d() = 0b1;
-  sccsr->e() = 0b1;
-  uccsr->d() = 0b1;
-  uccsr->e() = 0b1;
+  mccsr = legalize_ccsr(mccsr, zeros());
+  sccsr = legalize_ccsr(sccsr, zeros());
+  uccsr = legalize_ccsr(uccsr, zeros());
 }
 
 /* other hooks are not currently used. */

--- a/src/cheri_sys_regs.sail
+++ b/src/cheri_sys_regs.sail
@@ -67,7 +67,6 @@
 bitfield ccsr : xlenbits = {
   /* Bits allocated from 31 downwards are used for feature flags. */
   tc      :  31,     /* tag-clearing error semantics */
-  d       :  1,      /* dirty  */
   e       :  0       /* enable */
 }
 
@@ -84,7 +83,6 @@ function legalize_ccsr(c : ccsr, v : xlenbits) -> ccsr = {
   // assumed to legalize; so we could remove this function.
   let v = Mk_ccsr(v);
   /* For now these bits are not really supported so hardwired to true */
-  let c = update_d(c, 0b1);
   let c = update_e(c, 0b1);
   let c = update_tc(c, 0b1);
   c


### PR DESCRIPTION
It was never used and always hardcoded to one. While touching this code also avoid duplication in ext_init_regs() for the lower-mode CSRs by calling legalize_ccsr(zeros()), which will set the hardwired register bits.