### PR TITLE
Disable DDC relocation by default

### DIFF
--- a/src/cheri_addr_checks.sail
+++ b/src/cheri_addr_checks.sail
@@ -162,6 +162,14 @@ function ext_handle_control_check_error(err : ext_control_addr_error) -> unit = 
 
 type ext_data_addr_error = (CapEx, capreg_idx)
 
+/**
+ * Returns the current value of DDC (for subsequent access checks) as well as
+ * the resulting address for a non-CHERI integer-based memory access.
+ */
+function ddc_and_resulting_addr (addr : xlenbits) -> (Capability, xlenbits) = {
+  let ddc_val = DDC in
+  (ddc_val, if (have_ddc_relocation()) then ddc_val.address + addr else addr)
+}
 
 /*!
  * For given base register and offset returns, depending on current capability
@@ -174,8 +182,8 @@ function get_cheri_mode_cap_addr (base_reg : regidx, offset : xlenbits) = {
     let base_cap = C(base_reg) in
     (base_cap, base_cap.address + offset, 0b0 @ base_reg)
   else
-    let ddc = DDC in
-    (ddc, ddc.address + X(base_reg) + offset, DDC_IDX);
+    let (ddc_val, addr) = ddc_and_resulting_addr(X(base_reg) + offset) in
+    (ddc_val, addr, DDC_IDX);
 }
 
 function ext_data_get_addr(base_reg : regidx, offset : xlenbits, acc : AccessType(ext_access_type), width : word_width)

--- a/src/cheri_insts.sail
+++ b/src/cheri_insts.sail
@@ -1221,8 +1221,7 @@ union clause ast = LoadDataDDC : (regidx, regidx, bool, word_width)
  *   - **DDC**.**address** $+$ *rs1* $+$ *size* $\gt$ **DDC**.**top**.
  */
 function clause execute (LoadDataDDC(rd, rs1, is_unsigned, width)) = {
-  let ddc_val = DDC;
-  let vaddr = ddc_val.address + X(rs1);
+  let (ddc_val, vaddr) = ddc_and_resulting_addr(X(rs1));
   handle_load_data_via_cap(rd, DDC_IDX, ddc_val, vaddr, is_unsigned, width)
 }
 
@@ -1300,8 +1299,7 @@ union clause ast = LoadCapDDC : (regidx, regidx)
  *     implementation supports unaligned data accesses.
  */
 function clause execute (LoadCapDDC(cd, rs1)) = {
-  let ddc_val = DDC;
-  let vaddr = ddc_val.address + X(rs1);
+  let (ddc_val, vaddr) = ddc_and_resulting_addr(X(rs1));
   handle_load_cap_via_cap(cd, DDC_IDX, ddc_val, vaddr)
 }
 
@@ -1517,8 +1515,7 @@ if not(auth_val.tag) then {
 union clause ast = LoadResDataDDC : (regidx, regidx, word_width)
 function clause execute (LoadResDataDDC(rd, rs1, width)) = {
   if haveAtomics() then {
-    let ddc_val = DDC;
-    let vaddr = ddc_val.address + X(rs1);
+    let (ddc_val, vaddr) = ddc_and_resulting_addr(X(rs1));
     handle_loadres_data_via_cap(rd, DDC_IDX, ddc_val, vaddr, width)
   } else {
     handle_illegal();
@@ -1529,8 +1526,7 @@ function clause execute (LoadResDataDDC(rd, rs1, width)) = {
 union clause ast = LoadResCapDDC : (regidx, regidx)
 function clause execute (LoadResCapDDC(cd, rs1)) = {
   if haveAtomics() then {
-    let ddc_val = DDC;
-    let vaddr = ddc_val.address + X(rs1);
+    let (ddc_val, vaddr) = ddc_and_resulting_addr(X(rs1));
     handle_loadres_cap_via_cap(cd, DDC_IDX, ddc_val, vaddr, false, false)
   } else {
     handle_illegal();
@@ -1641,8 +1637,7 @@ union clause ast = StoreDataDDC : (regidx, regidx, word_width)
  *   - **DDC**.**address** $+$ *rs1* $+$ *size* $\gt$ **DDC**.**top**.
  */
 function clause execute (StoreDataDDC(rs2, rs1, width)) = {
-  let ddc_val = DDC;
-  let vaddr = ddc_val.address + X(rs1);
+  let (ddc_val, vaddr) = ddc_and_resulting_addr(X(rs1));
   handle_store_data_via_cap(rs2, DDC_IDX, ddc_val, vaddr, width)
 }
 
@@ -1730,8 +1725,7 @@ union clause ast = StoreCapDDC : (regidx, regidx)
  *   - **DDC**.**address** $+$ *rs1* $+$ **CLEN** $/$ 8 $\gt$ **DDC**.**top**.
  */
 function clause execute (StoreCapDDC(cs2, rs1)) = {
-  let ddc_val = DDC;
-  let vaddr = ddc_val.address + X(rs1);
+  let (ddc_val, vaddr) = ddc_and_resulting_addr(X(rs1));
   handle_store_cap_via_cap(cs2, DDC_IDX, ddc_val, vaddr)
 }
 
@@ -1972,8 +1966,7 @@ function clause execute StoreCondDataDDC(rs2, rs1, width) = {
     X(rs2) = EXTZ(0b1);
     RETIRE_SUCCESS
   } else if haveAtomics() then {
-    let ddc_val = DDC;
-    let vaddr = ddc_val.address + X(rs1);
+    let (ddc_val, vaddr) = ddc_and_resulting_addr(X(rs1));
     handle_store_cond_data_via_cap(rs2, DDC_IDX, ddc_val, vaddr, width)
   } else {
     handle_illegal();
@@ -1990,8 +1983,7 @@ function clause execute StoreCondCapDDC(cs2, rs1) = {
     C(cs2) = int_to_cap(EXTZ(0b1));
     RETIRE_SUCCESS
   } else if haveAtomics() then {
-    let ddc_val = DDC;
-    let vaddr = ddc_val.address + X(rs1);
+    let (ddc_val, vaddr) = ddc_and_resulting_addr(X(rs1));
     handle_store_cond_cap_via_cap(cs2, cs2, DDC_IDX, ddc_val, vaddr, false, false, true)
   } else {
     handle_illegal();

--- a/src/cheri_prelude.sail
+++ b/src/cheri_prelude.sail
@@ -72,3 +72,13 @@ val not = {coq:"negb", _:"not"} : bool -> bool
 
 val bool_to_bit : bool -> bit
 function bool_to_bit x = if x then bitone else bitzero
+
+/*
+ * DDC relocation will not be part of an initial standardized version of
+ * CHERI-RISC-V. However, it may be useful to enable for research
+ * prototypes and could potentially be an optional extensions, so we use
+ * this hardcoded boolean and a helper function (ddc_and_resulting_addr)
+ * to allow turning it back on again rather than removing the code outright.
+ */
+val have_ddc_relocation : unit -> bool
+function have_ddc_relocation() = false

--- a/src/cheri_sys_regs.sail
+++ b/src/cheri_sys_regs.sail
@@ -67,6 +67,7 @@
 bitfield ccsr : xlenbits = {
   /* Bits allocated from 31 downwards are used for feature flags. */
   tc      :  31,     /* tag-clearing error semantics */
+  ndr     :  30,     /* no DDC relocation */
   e       :  0       /* enable */
 }
 
@@ -82,8 +83,10 @@ function legalize_ccsr(c : ccsr, v : xlenbits) -> ccsr = {
   // Technically, WPRI does not need a legalizer, since software is
   // assumed to legalize; so we could remove this function.
   let v = Mk_ccsr(v);
-  /* For now these bits are not really supported so hardwired to true */
+  /* For now the e bit is not really supported so hardwired to true */
   let c = update_e(c, 0b1);
+  /* Read-only feature bits to allow for software to detect CHERI semantics. */
+  let c = update_ndr(c, bool_to_bits(not(have_ddc_relocation())));
   let c = update_tc(c, 0b1);
   c
 }


### PR DESCRIPTION
DDC relocation is no longer a mandatory part of the spec and is highly unlikely to be included as part of an initial standardized version of CHERI-RISC-V. In case we do decide to add DDC relocation as an optional extensions, this commit uses a (currently) hardcoded boolean and a helper function (maybe_ddc_relocated_addr) to allow turning it back on again rather than removing the code outright.

See https://github.com/CTSRD-CHERI/cheri-specification/issues/47