### PR TITLE
Disable PCC relocation by default

### DIFF
--- a/src/cheri_addr_checks.sail
+++ b/src/cheri_addr_checks.sail
@@ -104,7 +104,7 @@ val ext_fetch_check_pc : (xlenbits, xlenbits) -> Ext_FetchAddr_Check(ext_fetch_a
 function ext_fetch_check_pc(start_pc, pc) = {
   if   start_pc == pc
   then {
-    pcc_base = getCapBaseBits(PCC);
+    let pcc_base = getCapBaseBits(PCC);
     /* We need to perform the permission checks only for the first granule. */
     if      not(PCC.tag)
     then    Ext_FetchAddr_Error(CapEx_TagViolation)
@@ -112,9 +112,9 @@ function ext_fetch_check_pc(start_pc, pc) = {
     then    Ext_FetchAddr_Error(CapEx_SealViolation)
     else if not(PCC.permit_execute)
     then    Ext_FetchAddr_Error(CapEx_PermitExecuteViolation)
-    /* Require that PCC.base be as aligned as PC. This
-       is also enforced when setting PCC in most places. */
-    else if pcc_base[0] != bitzero | (pcc_base[1] != bitzero & ~(haveRVC()))
+    /* If PCC relocation is enabled, require that PCC.base be as aligned as PC.
+       This is also enforced when setting PCC in most places. */
+    else if have_pcc_relocation() & (pcc_base[0] != bitzero | (pcc_base[1] != bitzero & ~(haveRVC())))
     then    Ext_FetchAddr_Error(CapEx_UnalignedBase)
     else if not(inCapBounds(PCC, pc, 2))
     then    Ext_FetchAddr_Error(CapEx_LengthViolation)
@@ -136,12 +136,12 @@ type ext_control_addr_error = (CapEx, capreg_idx)
 
 /* the control address is derived from a non-PC register, e.g. in JALR */
 function ext_control_check_addr(pc : xlenbits) -> Ext_ControlAddr_Check(ext_control_addr_error) = {
-  let pcc_base = getCapBaseBits(PCC);
   /* We are given the addr without any bit[0] clearing, so the addition
    * below may include a set addr[0], and so the bounds checks should
    * be accurate.
    */
-  let target : xlenbits = [pcc_base + pc with 0=bitzero];
+  let pc = if have_pcc_relocation() then getCapBaseBits(PCC) + pc else pc;
+  let target : xlenbits = [pc with 0=bitzero];
   if   not(inCapBounds(PCC, target, min_instruction_bytes ()))
   then Ext_ControlAddr_Error(CapEx_LengthViolation, PCC_IDX)
   else Ext_ControlAddr_OK(target)

--- a/src/cheri_cap_common.sail
+++ b/src/cheri_cap_common.sail
@@ -486,6 +486,10 @@ function setCapAddr(c, addr) =
     let representable = capBoundsEqual(c, newCap) in
     (representable, newCap)
 
+function setCapAddrChecked(c, addr) : (Capability, CapAddrBits) -> Capability =
+    let (representable, newCap) = setCapAddr(c, addr) in
+    clearTagIf(newCap, not(representable) | isCapSealed(c))
+
 infix 1 >>_s
 overload operator >> = {sail_shiftright}
 overload operator << = {sail_shiftleft}
@@ -566,4 +570,24 @@ function getRepresentableAlignmentMask(len) : xlenbits -> xlenbits = {
 function getRepresentableLength(len) : xlenbits -> xlenbits = {
   let m = getRepresentableAlignmentMask(len);
   (len + ~(m)) & m
+}
+
+/**
+ * Returns an integer program counter from a given capability.
+ * By default this is equivalent to reading the address field of the capability,
+ * but if PCC relocation is enabled (not part of standardized CHERI-RISC-V) it
+ * returns the capability offset instead.
+ */
+function cap_to_integer_pc (cap: Capability) -> xlenbits = {
+  if (have_pcc_relocation()) then getCapOffsetBits(cap) else cap.address
+}
+
+/**
+ * Updates a capability to reference an integer program counter.
+ * By default this is equivalent to updating the address field of the capability,
+ * but if PCC relocation is enabled (not part of standardized CHERI-RISC-V) it
+ * updates the capability offset instead.
+ */
+function update_cap_with_integer_pc (cap: Capability, pc: xlenbits) -> Capability = {
+  if (have_pcc_relocation()) then setCapOffsetChecked(cap, pc) else setCapAddrChecked(cap, pc)
 }

--- a/src/cheri_insts.sail
+++ b/src/cheri_insts.sail
@@ -121,7 +121,7 @@ union clause ast = CJALR : (bits(12), regidx, regidx)
  *   - *cs1*.**perms** does not grant **Permit_Execute**.
  *   - *cs1*.**address** $+$ *imm* $\lt$ *cs1*.**base**.
  *   - *cs1*.**address** $+$ *imm* $+$ min_instruction_bytes $\gt$ *cs1*.**top**.
- *   - *cs1*.**base** is unaligned.
+ *   - *cs1*.**base** is unaligned (only possible if PCC relocation is enabled).
  *   - *cs1*.**address** $+$ *imm* is unaligned, ignoring bit 0.
  */
 function clause execute(CJALR(imm, cs1, cd)) = {
@@ -139,7 +139,7 @@ function clause execute(CJALR(imm, cs1, cd)) = {
   } else if not(cs1_val.permit_execute) then {
     handle_cheri_reg_exception(CapEx_PermitExecuteViolation, cs1);
     RETIRE_FAIL
-  } else if newPCCBase[0] == bitone | (newPCCBase[1] == bitone & ~(haveRVC())) then {
+  } else if have_pcc_relocation() & (newPCCBase[0] == bitone | (newPCCBase[1] == bitone & ~(haveRVC()))) then {
     handle_cheri_reg_exception(CapEx_UnalignedBase, cs1);
     RETIRE_FAIL
   } else if newPC[1] == bitone & ~(haveRVC()) then {
@@ -1069,7 +1069,7 @@ union clause ast = CInvoke : (regidx, regidx)
  *   - *cs2*.**perms** grants **Permit_Execute**.
  *   - *cs1*.**address** $\lt$ *cs1*.**base**.
  *   - *cs1*.**address** $+$ min_instruction_bytes $\gt$ *cs1*.**top**.
- *   - *cs1*.**base** is unaligned.
+ *   - *cs1*.**base** is unaligned (only possible if PCC relocation is enabled).
  *   - *cs1*.**address** is unaligned, ignoring bit 0.
  *
  * ## Notes
@@ -1114,7 +1114,7 @@ function clause execute (CInvoke(cs1, cs2)) = {
   } else if cs2_val.permit_execute then {
     handle_cheri_reg_exception(CapEx_PermitExecuteViolation, cs2);
     RETIRE_FAIL
-  } else if newPCCBase[0] == bitone | (newPCCBase[1] == bitone & ~(haveRVC())) then {
+  } else if have_pcc_relocation() & (newPCCBase[0] == bitone | (newPCCBase[1] == bitone & ~(haveRVC()))) then {
     handle_cheri_reg_exception(CapEx_UnalignedBase, cs1);
     RETIRE_FAIL
   } else if newPC[1] == bitone & ~(haveRVC()) then {
@@ -1146,7 +1146,7 @@ union clause ast = JALR_CAP : (regidx, regidx)
  *   - *cs1*.**perms** does not grant **Permit_Execute**.
  *   - *cs1*.**address** $\lt$ *cs1*.**base**.
  *   - *cs1*.**address** $+$ min_instruction_bytes $\gt$ *cs1*.**top**.
- *   - *cs1*.**base** is unaligned.
+ *   - *cs1*.**base** is unaligned (only possible if PCC relocation is enabled).
  *   - *cs1*.**address** is unaligned, ignoring bit 0.
  */
 function clause execute(JALR_CAP(cd, cs1)) = {

--- a/src/cheri_misa_ext.sail
+++ b/src/cheri_misa_ext.sail
@@ -62,4 +62,8 @@
 
 /* Veto disabling C if PCC.base is not 4-byte aligned
    (assuming it is already 2-byte aligned) */
-function ext_veto_disable_C () = getCapBaseBits(PCC)[1] == bitone
+function ext_veto_disable_C () = {
+  if have_pcc_relocation()
+  then getCapBaseBits(PCC)[1] == bitone
+  else false
+}

--- a/src/cheri_pc_access.sail
+++ b/src/cheri_pc_access.sail
@@ -64,10 +64,11 @@
 
 val get_arch_pc : unit -> xlenbits effect {rreg}
 function get_arch_pc () =
-  PC - getCapBaseBits(PCC)
+  if have_pcc_relocation() then PC - getCapBaseBits(PCC) else PC
 
-/* FIXME: The asymmetry between get_next_pc and set_next_pc where one
- * returns the architectural PC but the other set the PCC-relative PC
+/* FIXME: When have_pcc_relocation() is true, there is asymmetry
+ * between get_next_pc and set_next_pc where one returns the
+ * architectural PC but the other set the PCC-relative PC, which
  * is a bit weird. The way they are currently used it is correct but
  * we should either rename one of the functions or call set_next_pc
  * with the original target address instead of the munged one. - RNW.
@@ -75,7 +76,7 @@ function get_arch_pc () =
 
 val get_next_pc : unit -> xlenbits effect {rreg}
 function get_next_pc() =
-  nextPC - getCapBaseBits(PCC)
+  if have_pcc_relocation() then nextPC - getCapBaseBits(PCC) else nextPC
 
 val set_next_pc : xlenbits -> unit effect {wreg}
 function set_next_pc(pc) =

--- a/src/cheri_prelude.sail
+++ b/src/cheri_prelude.sail
@@ -82,3 +82,12 @@ function bool_to_bit x = if x then bitone else bitzero
  */
 val have_ddc_relocation : unit -> bool
 function have_ddc_relocation() = false
+
+/*
+ * PCC relocation will not be part of an initial standardized version of
+ * CHERI-RISC-V. Without PCC relocation the RISC-V integer PC is always
+ * equal to PCC.address which allows us to simplify various corner cases
+ * (e.g. writes to SCRs that could end up in PCC)
+ */
+val have_pcc_relocation : unit -> bool
+function have_pcc_relocation() = false

--- a/src/cheri_prelude.sail
+++ b/src/cheri_prelude.sail
@@ -74,6 +74,14 @@ val bool_to_bit : bool -> bit
 function bool_to_bit x = if x then bitone else bitzero
 
 /*
+ * We use a single feature flag controlling DDC/PCC relocation.
+ * However, the code uses two separate guards to make it possible
+ * to bring back only one of the two for future experiments.
+ */
+val have_cheri_relocation : unit -> bool
+function have_cheri_relocation() = false
+
+/*
  * DDC relocation will not be part of an initial standardized version of
  * CHERI-RISC-V. However, it may be useful to enable for research
  * prototypes and could potentially be an optional extensions, so we use
@@ -81,7 +89,7 @@ function bool_to_bit x = if x then bitone else bitzero
  * to allow turning it back on again rather than removing the code outright.
  */
 val have_ddc_relocation : unit -> bool
-function have_ddc_relocation() = false
+function have_ddc_relocation() = have_cheri_relocation()
 
 /*
  * PCC relocation will not be part of an initial standardized version of
@@ -90,4 +98,4 @@ function have_ddc_relocation() = false
  * (e.g. writes to SCRs that could end up in PCC)
  */
 val have_pcc_relocation : unit -> bool
-function have_pcc_relocation() = false
+function have_pcc_relocation() = have_cheri_relocation()

--- a/src/cheri_sys_exceptions.sail
+++ b/src/cheri_sys_exceptions.sail
@@ -121,7 +121,7 @@ function get_xret_target(p) = {
     Supervisor => SEPCC,
     User       => UEPCC
   };
-  legalize_xepc(getCapOffsetBits(cap))
+  legalize_xepc(cap_to_integer_pc(cap))
 }
 
 /*
@@ -134,9 +134,9 @@ function get_xret_target(p) = {
 val set_xret_target : (Privilege, xlenbits) -> xlenbits effect {rreg, wreg}
 function set_xret_target(p, value) = {
   match p {
-    Machine    => MEPCC = setCapOffsetChecked(MEPCC, value),
-    Supervisor => SEPCC = setCapOffsetChecked(SEPCC, value),
-    User       => UEPCC = setCapOffsetChecked(UEPCC, value)
+    Machine    => MEPCC = update_cap_with_integer_pc(MEPCC, value),
+    Supervisor => SEPCC = update_cap_with_integer_pc(SEPCC, value),
+    User       => UEPCC = update_cap_with_integer_pc(UEPCC, value)
   };
   value
 }
@@ -168,28 +168,28 @@ function prepare_xret_target(p) = {
 /* other trap-related CSRs */
 
 function get_mtvec() -> xlenbits =
-  getCapOffsetBits(MTCC)
+  cap_to_integer_pc(MTCC)
 
 function get_stvec() -> xlenbits =
-  getCapOffsetBits(STCC)
+  cap_to_integer_pc(STCC)
 
 function get_utvec() -> xlenbits =
-  getCapOffsetBits(UTCC)
+  cap_to_integer_pc(UTCC)
 
 function set_mtvec(value : xlenbits) -> xlenbits = {
-  let mtv = legalize_tvec(Mk_Mtvec(getCapOffsetBits(MTCC)), value);
-  MTCC = setCapOffsetChecked(MTCC, mtv.bits());
+  let mtv = legalize_tvec(Mk_Mtvec(cap_to_integer_pc(MTCC)), value);
+  MTCC = update_cap_with_integer_pc(MTCC, mtv.bits());
   mtv.bits()
 }
 
 function set_stvec(value : xlenbits) -> xlenbits = {
-  let stv = legalize_tvec(Mk_Mtvec(getCapOffsetBits(STCC)), value);
-  STCC = setCapOffsetChecked(STCC, stv.bits());
+  let stv = legalize_tvec(Mk_Mtvec(cap_to_integer_pc(STCC)), value);
+  STCC = update_cap_with_integer_pc(STCC, stv.bits());
   stv.bits()
 }
 
 function set_utvec(value : xlenbits) -> xlenbits = {
-  let utv = legalize_tvec(Mk_Mtvec(getCapOffsetBits(UTCC)), value);
-  UTCC = setCapOffsetChecked(UTCC, utv.bits());
+  let utv = legalize_tvec(Mk_Mtvec(cap_to_integer_pc(UTCC)), value);
+  UTCC = update_cap_with_integer_pc(UTCC, utv.bits());
   utv.bits()
 }

--- a/src/cheri_sys_regs.sail
+++ b/src/cheri_sys_regs.sail
@@ -67,8 +67,7 @@
 bitfield ccsr : xlenbits = {
   /* Bits allocated from 31 downwards are used for feature flags. */
   tc      :  31,     /* tag-clearing error semantics */
-  ndr     :  30,     /* no DDC relocation */
-  npr     :  29,     /* no PCC relocation */
+  nr      :  30,     /* no DDC/PCC relocation */
   e       :  0       /* enable */
 }
 
@@ -87,8 +86,7 @@ function legalize_ccsr(c : ccsr, v : xlenbits) -> ccsr = {
   /* For now the e bit is not really supported so hardwired to true */
   let c = update_e(c, 0b1);
   /* Read-only feature bits to allow for software to detect CHERI semantics. */
-  let c = update_npr(c, bool_to_bits(not(have_pcc_relocation())));
-  let c = update_ndr(c, bool_to_bits(not(have_ddc_relocation())));
+  let c = update_nr(c, bool_to_bits(not(have_cheri_relocation())));
   let c = update_tc(c, 0b1);
   c
 }

--- a/src/cheri_sys_regs.sail
+++ b/src/cheri_sys_regs.sail
@@ -68,6 +68,7 @@ bitfield ccsr : xlenbits = {
   /* Bits allocated from 31 downwards are used for feature flags. */
   tc      :  31,     /* tag-clearing error semantics */
   ndr     :  30,     /* no DDC relocation */
+  npr     :  29,     /* no PCC relocation */
   e       :  0       /* enable */
 }
 
@@ -86,6 +87,7 @@ function legalize_ccsr(c : ccsr, v : xlenbits) -> ccsr = {
   /* For now the e bit is not really supported so hardwired to true */
   let c = update_e(c, 0b1);
   /* Read-only feature bits to allow for software to detect CHERI semantics. */
+  let c = update_npr(c, bool_to_bits(not(have_pcc_relocation())));
   let c = update_ndr(c, bool_to_bits(not(have_ddc_relocation())));
   let c = update_tc(c, 0b1);
   c
@@ -143,15 +145,15 @@ function haveXcheri () -> bool =
 
 
 function legalize_tcc(o : Capability, v : Capability) -> Capability = {
-  new_base = getCapBaseBits(v);
+  let new_base = getCapBaseBits(v);
   /* Ignore writes that attempt to set unaligned TCC base */
-  if new_base[0] != bitzero | new_base[1] != bitzero then
+  if have_pcc_relocation() & (new_base[0] != bitzero | new_base[1] != bitzero) then
     o /* keep original TCC value */
   else {
-    /* legalize new TCC offset (RISC-V tvec) */
-    new_tvec = v.address - new_base;
-    legalized_tvec = legalize_tvec(Mk_Mtvec(getCapOffsetBits(o)), new_tvec);
-    setCapOffsetChecked(v, legalized_tvec.bits())
+    /* legalize new TCC (RISC-V tvec) */
+    let new_tvec = cap_to_integer_pc(v);
+    let legalized_tvec = legalize_tvec(Mk_Mtvec(cap_to_integer_pc(o)), new_tvec);
+    update_cap_with_integer_pc(v, legalized_tvec.bits())
   }
 }
 
@@ -175,10 +177,10 @@ function legalize_tcc(o : Capability, v : Capability) -> Capability = {
  * untagged lie.
  */
 function legalize_epcc (v : Capability) -> Capability = {
-  let voffset = getCapOffsetBits(v);
-  let legalized = legalize_xepc(voffset);
+  let int_val = cap_to_integer_pc(v);
+  let legalized = legalize_xepc(int_val);
 
-  if   legalized == voffset
+  if   legalized == int_val
   then v /* avoid possibly attempting to set the offset of a sentry */
-  else setCapOffsetChecked(v, legalized)
+  else update_cap_with_integer_pc(v, legalized)
 }


### PR DESCRIPTION
This is somewhat more invasive than the change to disable DDC relocation, so we might want to remove the fallback code outright rather than keeping a have_pcc_relocation() configuration option.