### PR TITLE
Move bounds check after PC/PCC misalignment checks

### DIFF
--- a/src/cheri_addr_checks.sail
+++ b/src/cheri_addr_checks.sail
@@ -112,12 +112,12 @@ function ext_fetch_check_pc(start_pc, pc) = {
     then    Ext_FetchAddr_Error(CapEx_SealViolation)
     else if not(PCC.permit_execute)
     then    Ext_FetchAddr_Error(CapEx_PermitExecuteViolation)
-    else if not(inCapBounds(PCC, pc, 2))
-    then    Ext_FetchAddr_Error(CapEx_LengthViolation)
     /* Require that PCC.base be as aligned as PC. This
        is also enforced when setting PCC in most places. */
     else if pcc_base[0] != bitzero | (pcc_base[1] != bitzero & ~(haveRVC()))
     then    Ext_FetchAddr_Error(CapEx_UnalignedBase)
+    else if not(inCapBounds(PCC, pc, 2))
+    then    Ext_FetchAddr_Error(CapEx_LengthViolation)
     else    Ext_FetchAddr_OK(pc)
   } else {
     /* Perform only the bounds checks on the current granule, i.e. pc. */

--- a/src/cheri_insts.sail
+++ b/src/cheri_insts.sail
@@ -139,14 +139,14 @@ function clause execute(CJALR(imm, cs1, cd)) = {
   } else if not(cs1_val.permit_execute) then {
     handle_cheri_reg_exception(CapEx_PermitExecuteViolation, cs1);
     RETIRE_FAIL
-  } else if not(inCapBounds(cs1_val, newPC, min_instruction_bytes())) then {
-    handle_cheri_reg_exception(CapEx_LengthViolation, cs1);
-    RETIRE_FAIL
   } else if newPCCBase[0] == bitone | (newPCCBase[1] == bitone & ~(haveRVC())) then {
     handle_cheri_reg_exception(CapEx_UnalignedBase, cs1);
     RETIRE_FAIL
   } else if newPC[1] == bitone & ~(haveRVC()) then {
     handle_mem_exception(newPC,  E_Fetch_Addr_Align());
+    RETIRE_FAIL
+  } else if not(inCapBounds(cs1_val, newPC, min_instruction_bytes())) then {
+    handle_cheri_reg_exception(CapEx_LengthViolation, cs1);
     RETIRE_FAIL
   } else {
     let (success, linkCap) = setCapAddr(PCC, nextPC); /* Note that nextPC accounts for compressed instructions */
@@ -1114,14 +1114,14 @@ function clause execute (CInvoke(cs1, cs2)) = {
   } else if cs2_val.permit_execute then {
     handle_cheri_reg_exception(CapEx_PermitExecuteViolation, cs2);
     RETIRE_FAIL
-  } else if not(inCapBounds(cs1_val, newPC, min_instruction_bytes())) then {
-    handle_cheri_reg_exception(CapEx_LengthViolation, cs1);
-    RETIRE_FAIL
   } else if newPCCBase[0] == bitone | (newPCCBase[1] == bitone & ~(haveRVC())) then {
     handle_cheri_reg_exception(CapEx_UnalignedBase, cs1);
     RETIRE_FAIL
   } else if newPC[1] == bitone & ~(haveRVC()) then {
     handle_mem_exception(newPC,  E_Fetch_Addr_Align());
+    RETIRE_FAIL
+  } else if not(inCapBounds(cs1_val, newPC, min_instruction_bytes())) then {
+    handle_cheri_reg_exception(CapEx_LengthViolation, cs1);
     RETIRE_FAIL
   } else {
     C(31) = unsealCap(cs2_val);


### PR DESCRIPTION
This allows hardware to delay the bounds check. See discussion at https://github.com/CTSRD-CHERI/cheri-specification/issues/54