### PR TITLE
Print CHERI SCR updates in traces

### DIFF
--- a/src/cheri_insts.sail
+++ b/src/cheri_insts.sail
@@ -425,7 +425,9 @@ function clause execute (CSpecialRW(cd, scr, cs1)) = {
         30 => MScratchC = cs1_val,
         31 => MEPCC = cs1_val,
         _  => assert(false, "unreachable")
-      }
+      };
+      if get_config_print_reg() then
+        print_reg(scr_name_map(scr) ^ " <- " ^ RegStr(cs1_val));
     };
     RETIRE_SUCCESS
   }


### PR DESCRIPTION
This updates CSpecialRW to include the new value that was written to the CSR which helps when scanning traces for the latest value.