### PR TITLE
Fix LaTeX documentation for ddc_and_result_addr

### DIFF
--- a/src/cheri_addr_checks.sail
+++ b/src/cheri_addr_checks.sail
@@ -167,7 +167,8 @@ type ext_data_addr_error = (CapEx, capreg_idx)
  * Returns the current value of DDC (for subsequent access checks) as well as
  * the resulting address for a non-CHERI integer-based memory access.
  */
-function ddc_and_resulting_addr (addr : xlenbits) -> (Capability, xlenbits) = {
+val ddc_and_resulting_addr : (xlenbits) -> (Capability, xlenbits)
+function ddc_and_resulting_addr (addr) = {
   let ddc_val = DDC in
   (ddc_val, if (have_ddc_relocation()) then ddc_val.address + addr else addr)
 }

--- a/src/cheri_addr_checks.sail
+++ b/src/cheri_addr_checks.sail
@@ -163,7 +163,7 @@ function ext_handle_control_check_error(err : ext_control_addr_error) -> unit = 
 
 type ext_data_addr_error = (CapEx, capreg_idx)
 
-/**
+/*!
  * Returns the current value of DDC (for subsequent access checks) as well as
  * the resulting address for a non-CHERI integer-based memory access.
  */


### PR DESCRIPTION
It needs to be on the `val`, adding it to the `function` prevents it from being visible in the CHERI specification.