### PR TITLE
Include the Zb* extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,10 @@ SAIL_DEFAULT_INST = $(SAIL_RISCV_MODEL_DIR)/riscv_insts_base.sail \
                     $(SAIL_RISCV_MODEL_DIR)/riscv_insts_cfext.sail \
                     $(SAIL_RISCV_MODEL_DIR)/riscv_insts_dext.sail \
                     $(SAIL_RISCV_MODEL_DIR)/riscv_insts_cdext.sail \
+                    $(SAIL_RISCV_MODEL_DIR)/riscv_insts_zba.sail \
+                    $(SAIL_RISCV_MODEL_DIR)/riscv_insts_zbb.sail \
+                    $(SAIL_RISCV_MODEL_DIR)/riscv_insts_zbc.sail \
+                    $(SAIL_RISCV_MODEL_DIR)/riscv_insts_zbs.sail \
                     $(SAIL_CHERI_MODEL_DIR)/cheri_insts_begin.sail \
                     $(SAIL_CHERI_MODEL_DIR)/cheri_insts.sail \
                     $(SAIL_CHERI_MODEL_DIR)/cheri_insts_cext.sail \


### PR DESCRIPTION
These are part of the mandatory RVA22 profile, so it makes sense to include them here. Future changes could be changing the semantics of Zba to return capabilities instead of integers, but the instructions can also be useful as defined right now.